### PR TITLE
New GF Guide index with rearranged texts and sections

### DIFF
--- a/gf-guide/culture.md
+++ b/gf-guide/culture.md
@@ -1,6 +1,6 @@
 # Libre Font Culture
 
-> <span class="icon">🦉</span>  The design community and the tech community traditionally have very different cultures. Designer culture often involves the work of a single artist-designer that usually prefers to protect their artwork, while software developers generally cannot operate in such a solitary fashion: their work, even if it is copyrighted, is often based on the work of others and more subject to fragmented authorship. <br>
+> <span class="icon">🦉</span>  The design community and the tech community traditionally have very different cultures. Designer culture often involves the work of a single artist-designer that usually prefers to protect their artwork, while software developers generally cannot operate in such a solitary fashion: their work, even if it is copyrighted, is often based on the work of others and more subject to fragmented authorship. <br><br>
 > Since fonts are software, Google Fonts works at the intersection of the two communities and, for many reasons, has embraced the Libre software culture to promote the creation, development, and distribution of typefaces. This culture encourages participation and learning while facilitating sharing and collaboration through the openness of the work and a more flexible licensing schema. <br>
 > It is helpful for type designers to understand the typical operation of a software project. This page aims to help type designers involved in starting or participating in Libre Font projects to know how libre software projects operate.
 

--- a/gf-guide/culture.md
+++ b/gf-guide/culture.md
@@ -1,14 +1,8 @@
 # Libre Font Culture
-{:.no_toc}
 
-> <span class="icon">🐹</span>  The design community and the tech community traditionally have very different cultures. Designer culture often involves the work of a single artist-designer and insists on protecting their artwork, while software developers generally cannot operate in such a solitary fashion: their work, even if it is copyrighted, is often based on the work of others and more subject to fragmented authorship.
-> Since fonts are software, Google Fonts works at the intersection of the two communities and, for many reasons, has embraced the Libre software culture to promote the creation, development, and distribution of typefaces. This culture encourages participation and learning while facilitating sharing and collaboration through the openness of the work and a more flexible licensing schema.
+> <span class="icon">🦉</span>  The design community and the tech community traditionally have very different cultures. Designer culture often involves the work of a single artist-designer that usually prefers to protect their artwork, while software developers generally cannot operate in such a solitary fashion: their work, even if it is copyrighted, is often based on the work of others and more subject to fragmented authorship. <br>
+> Since fonts are software, Google Fonts works at the intersection of the two communities and, for many reasons, has embraced the Libre software culture to promote the creation, development, and distribution of typefaces. This culture encourages participation and learning while facilitating sharing and collaboration through the openness of the work and a more flexible licensing schema. <br>
 > It is helpful for type designers to understand the typical operation of a software project. This page aims to help type designers involved in starting or participating in Libre Font projects to know how libre software projects operate.
-
-## Table of contents
-{:.no_toc}
-* TOC goes here
-{:toc}
 
 ## Four Freedoms
 

--- a/gf-guide/index.md
+++ b/gf-guide/index.md
@@ -12,71 +12,103 @@
 
 The most basic concepts, tools, or knowledge you will need to cover to begin contributing with Google Fonts.
 
-* <b>[Libre Font Culture](culture.md)</b> `Starting Point`
-* <b>[Required Knowledge](https://googlefonts.github.io/gf-guide/tools.html#required-knowledge)</b> `Starting Point`
-* <b>[Setting up a working environment](https://googlefonts.github.io/gf-guide/tools.</b>html#setting-up-a-working-environment)</b> `Starting Point`
-* <b>[Installing the required tools](https://googlefonts.github.io/gf-guide/tools.html#installing-the-required-tools)</b> `Starting Point`
-* <b>[Hosting projects on Github](hosting.md)</b> `Learn`
+* <b>[Libre Font Culture](culture.md)</b>
+  <span style="background-color:#dee0ff; color:#5f6dd1; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Starting Point</span>
+* <b>[Required Knowledge](https://googlefonts.github.io/gf-guide/tools.html#required-knowledge)</b>
+  <span style="background-color:#dee0ff; color:#5f6dd1; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Starting Point</span>
+* <b>[Setting up a working environment](https://googlefonts.github.io/gf-guide/tools.</b>html#setting-up-a-working-environment)</b>
+  <span style="background-color:#dee0ff; color:#5f6dd1; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Starting Point</span>
+* <b>[Installing the required tools](https://googlefonts.github.io/gf-guide/tools.html#installing-the-required-tools)</b>
+  <span style="background-color:#dee0ff; color:#5f6dd1; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Starting Point</span>
+* <b>[Hosting projects on Github](hosting.md)</b>
+  <span style="background-color:#dee0ff; color:#5f6dd1; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Starting Point</span>
 
 ## The Upstream Repo: allocate and administrate your project files
 
 To improve and facilitate the open collaborative process as well as the publishing process, we require an specific structure for your files on the GitHub repository.
 
-* <b>[Upstream repository structure](upstream.md)</b> `Must Read`
-* <b>[README file](readmefile.md)</b> `Must Read`
+* <b>[Upstream repository structure](upstream.md)</b>
+  <span style="background-color:#ffd7f1; color:#926b85; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Must Read</span>
+* <b>[README file](readmefile.md)</b>
+  <span style="background-color:#ffd7f1; color:#926b85; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Must Read</span>
 <br><br>
-* [Authors and Contributors](authors.md) `Template`
-* [License file](license.md) `Template`
-* [Maintaining your font repo](maintaining.md) `Learn`
+* [Maintaining your font repo](maintaining.md) 
+  <span style="background-color:#efefff; color:#74758b; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Learn</span>
+* [Authors and Contributors](authors.md)
+  <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Template</span>
+* [License file](license.md)
+  <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Template</span>
 
 ## Pre-production: Getting your fonts ready for GF
 
 Know the particularities about mastering your font project to meet the Google Fonts specifications and get them ready for production.
 
-* <b>[New fonts specifics](https://googlefonts.github.io/gf-guide/onboarding.html#new-fonts)</b> `Starting Point`
-* <b>[Upgrading fonts specifics](https://googlefonts.github.io/gf-guide/onboarding.html#font-upgrades)</b> `Starting Point`
-* <b>[Overall font files requirements](requirements.md)</b> `Must Read`
-* <b>[Static fonts specifics](statics.md)</b> `Must Read`
-* <b>[Variable fonts specifics](variable.md)</b> `Must Read`
-* <b>[Vertical metrics](metrics.md)</b> `Must Read`
+* <b>[New fonts specifics](https://googlefonts.github.io/gf-guide/onboarding.html#new-fonts)</b>
+  <span style="background-color:#dee0ff; color:#5f6dd1; padding:1px;  font-family:'Andale Mono'; font-size:0.9em">Starting Point</span>
+* <b>[Upgrading fonts specifics](https://googlefonts.github.io/gf-guide/onboarding.html#font-upgrades)</b>
+  <span style="background-color:#dee0ff; color:#5f6dd1; padding:1px;  font-family:'Andale Mono'; font-size:0.9em">Starting Point</span>
+* <b>[Overall font files requirements](requirements.md)</b>
+  <span style="background-color:#ffd7f1; color:#926b85; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Must Read</span>
+* <b>[Static fonts specifics](statics.md)</b>
+  <span style="background-color:#ffd7f1; color:#926b85; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Must Read</span>
+* <b>[Variable fonts specifics](variable.md)</b>
+  <span style="background-color:#ffd7f1; color:#926b85; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Must Read</span>
+* <b>[Vertical metrics](metrics.md)</b>
+  <span style="background-color:#ffd7f1; color:#926b85; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Must Read</span>
 <br><br>
-* [Refining your typeface](refining.md) `Learn`
-* [Outline Quality](outlines.md) `Learn`
+* [Refining your typeface](refining.md)
+  <span style="background-color:#efefff; color:#74758b; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Learn</span>
+* [Outline Quality](outlines.md) 
+  <span style="background-color:#efefff; color:#74758b; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Learn</span>
 
 ## Production: compiling your fonts for GF
 
 Context on the requirements to produce the fonts and get them ready for publishing.
 
-* <b>[Massively distribution implications](https://googlefonts.github.io/gf-guide/production.html#fonts-are-massively-distributed)</b> `Starting Point`
-* <b>[Scalable font production](https://googlefonts.github.io/gf-guide/production.html#scalable-font-production)</b> `Must Read`
+* <b>[Massively distribution implications](https://googlefonts.github.io/gf-guide/production.html#fonts-are-massively-distributed)</b>
+  <span style="background-color:#dee0ff; color:#5f6dd1; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Starting Point</span>
+* <b>[Scalable font production](https://googlefonts.github.io/gf-guide/production.html#scalable-font-production)</b>
+  <span style="background-color:#ffd7f1; color:#926b85; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Must Read</span>
 <br><br>
-* [Build the fonts](build.md) `Learn`
-* [QA tools](qa.md) `Learn`
-* [Local testing](testing.md) `Learn`
+* [Build the fonts](build.md) 
+  <span style="background-color:#efefff; color:#74758b; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Learn</span>
+* [QA tools](qa.md) 
+  <span style="background-color:#efefff; color:#74758b; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Learn</span>
+* [Local testing](testing.md) 
+  <span style="background-color:#efefff; color:#74758b; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Learn</span>
 
 
 ## The google/fonts repository 
 
 Details on the Google Fonts `Fonts` repository that host the fonts already included in the Catalogue.
 
-* [google/fonts repository explained](googlefonts.md) `Nerd`
+* [google/fonts repository explained](googlefonts.md)
+  <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Nerd</span>
 
 
 ## Onboarding Fonts to GF
 
 Advanced content for experienced contributors or Team member with the details on the publishing process.
 
-* [Making a PR to Google Fonts](making-pr.md) `Nerd`
-* [Package the fonts](package.md) `Team Member`
-* [Onboarder workflow guide](onboarder-workflow.md) `Team Member`
-* [METADATA file](metadata.md) `Team Member`
-* [Description file](description.md) `Team Member`
-* [Designer Profile](profile.md) `Template`
-* [Promo / Marketing](marketing.md) `Template`
+* [Making a PR to Google Fonts](making-pr.md)
+  <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Nerd</span>
+* [Package the fonts](package.md) 
+  <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Team Member</span>
+* [Onboarder workflow guide](onboarder-workflow.md) 
+  <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Team Member</span>
+* [METADATA file](metadata.md) 
+  <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Team Member</span>
+* [Description file](description.md)
+  <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Team Member</span>
+* [Designer Profile](profile.md) 
+  <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Template</span>
+* [Promo / Marketing](marketing.md) 
+  <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Template</span>
 
 <!-- ## More info
 
 Overall knowledge 
 
-* [The font tables explained](fonttables.md) `Learn` -->
+* [The font tables explained](fonttables.md) 
+<span style="background-color:#efefff; color:#74758b; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Learn</span> -->
 

--- a/gf-guide/index.md
+++ b/gf-guide/index.md
@@ -1,53 +1,82 @@
 # Google Fonts Guide
 
-> 🦜 This guide aims to help people to navigate requirements and recommendations to contribute to [Google Fonts](https://fonts.google.com).
-This documentation is not meant to be read at once. For example, some people are more empowered with the use of Github and can skip some chapters, or you are only interested in how to make better outlines. The guidelines have been separated into small bits to facilitate the search of specific informations that you would need at a specific stage of the font production.
-If you’re a **type designer** and you want to **contribute** fonts to Google Fonts, whether commissioned or as a voluntary contribution, you should read the chapters marked with `Starting point` and `Must read`. Additional resources are available under the `Learn` label.
-If you are **onboarding** fonts to Google Fonts, or for very advanced users, the chapters marked with `Team Member` and `Nerd` are for you.
+> 🦜 This guide aims to help people to navigate requirements and recommendations to contribute to [Google Fonts](https://fonts.google.com). The contents covered here range from general knowledge to contextualize the _what_ and _why_ of some of the requirements as well as the specifics regarding technical aspects with some suggestions on how to comply with them. It covers different levels of information for both newcomers and more experienced contributors.
+>
+> Therefore, **this documentation is not meant to be read at once**. If you are already familiar with some of the concepts, for example, some people are more empowered with the use of Github please you can skip some chapters and jump to the other bits that you may be looking for. The guidelines have been separated into small bits to facilitate the search of specific informations that you would need at a specific stage of the font production.
+>
+> If you’re a **newcomer** and you want to **contribute** fonts to Google Fonts, whether commissioned or as a voluntary contribution, you should read the chapters marked with `Starting point` and `Must read`. Additional resources are available under the `Learn` label.
+> 
+> If you are an **experienced** user or are **onboarding** fonts to Google Fonts, the chapters marked with `Team Member` and `Nerd` are for you.
 
-## Introduction
+## Introduction: getting familiar with the basics
 
-* [Google Fonts Guide TL;DR](tldr.md) `Starting Point`
-* [Libre Font Culture](culture.md) `Learn`
-* [Tools and Dependencies](tools.md) `Starting Point`
-* [Hosting projects on Github](hosting.md) `Learn`
-* [google/fonts repository explained](googlefonts.md) `Nerd`
+The most basic concepts, tools, or knowledge you will need to cover to begin contributing with Google Fonts.
 
-## Onboarding Fonts to GF
-* [Production requirements](production.md) `Starting Point`
-* [Adding & upgrading fonts to Google Fonts](onboarding.md) `Starting Point`
-* [Making a PR to Google Fonts](making-pr.md) `Nerd`
-* [Onboarder workflow guide](onboarder-workflow.md) `Team Member`
-* [METADATA file](metadata.md) `Team Member`
-* [Description file](description.md) `Team Member`
-* [Designer Profile](profile.md) `Template`
-* [Promo / Marketing](marketing.md) `Template`
+* <b>[Libre Font Culture](culture.md)</b> `Starting Point`
+* <b>[Required Knowledge](https://googlefonts.github.io/gf-guide/tools.html#required-knowledge)</b> `Starting Point`
+* <b>[Setting up a working environment](https://googlefonts.github.io/gf-guide/tools.</b>html#setting-up-a-working-environment)</b> `Starting Point`
+* <b>[Installing the required tools](https://googlefonts.github.io/gf-guide/tools.html#installing-the-required-tools)</b> `Starting Point`
+* <b>[Hosting projects on Github](hosting.md)</b> `Learn`
 
-## The Upstream Repo
+## The Upstream Repo: allocate and administrate your project files
 
-* [Upstream repository structure](upstream.md) `Must Read`
-* [README file](readmefile.md) `Must Read`
+To improve and facilitate the open collaborative process as well as the publishing process, we require an specific structure for your files on the GitHub repository.
+
+* <b>[Upstream repository structure](upstream.md)</b> `Must Read`
+* <b>[README file](readmefile.md)</b> `Must Read`
+<br><br>
 * [Authors and Contributors](authors.md) `Template`
 * [License file](license.md) `Template`
 * [Maintaining your font repo](maintaining.md) `Learn`
 
 ## Pre-production: Getting your fonts ready for GF
 
-* [Overall font files requirements](requirements.md) `Must Read`
-* [Static fonts specifics](statics.md) `Must Read`
-* [Variable fonts specifics](variable.md) `Must Read`
-* [Vertical metrics](metrics.md) `Must Read`
+Know the particularities about mastering your font project to meet the Google Fonts specifications and get them ready for production.
+
+* <b>[New fonts specifics](https://googlefonts.github.io/gf-guide/onboarding.html#new-fonts)</b> `Starting Point`
+* <b>[Upgrading fonts specifics](https://googlefonts.github.io/gf-guide/onboarding.html#font-upgrades)</b> `Starting Point`
+* <b>[Overall font files requirements](requirements.md)</b> `Must Read`
+* <b>[Static fonts specifics](statics.md)</b> `Must Read`
+* <b>[Variable fonts specifics](variable.md)</b> `Must Read`
+* <b>[Vertical metrics](metrics.md)</b> `Must Read`
+<br><br>
 * [Refining your typeface](refining.md) `Learn`
 * [Outline Quality](outlines.md) `Learn`
 
-## More about tools, build, and QA
+## Production: compiling your fonts for GF
 
-* [Build the fonts](build.md) `Nerd`
-* [QA tools](qa.md) `Nerd`
+Context on the requirements to produce the fonts and get them ready for publishing.
+
+* <b>[Massively distribution implications](https://googlefonts.github.io/gf-guide/production.html#fonts-are-massively-distributed)</b> `Starting Point`
+* <b>[Scalable font production](https://googlefonts.github.io/gf-guide/production.html#scalable-font-production)</b> `Must Read`
+<br><br>
+* [Build the fonts](build.md) `Learn`
+* [QA tools](qa.md) `Learn`
 * [Local testing](testing.md) `Learn`
+
+
+## The google/fonts repository 
+
+Details on the Google Fonts `Fonts` repository that host the fonts already included in the Catalogue.
+
+* [google/fonts repository explained](googlefonts.md) `Nerd`
+
+
+## Onboarding Fonts to GF
+
+Advanced content for experienced contributors or Team member with the details on the publishing process.
+
+* [Making a PR to Google Fonts](making-pr.md) `Nerd`
 * [Package the fonts](package.md) `Team Member`
+* [Onboarder workflow guide](onboarder-workflow.md) `Team Member`
+* [METADATA file](metadata.md) `Team Member`
+* [Description file](description.md) `Team Member`
+* [Designer Profile](profile.md) `Template`
+* [Promo / Marketing](marketing.md) `Template`
 
-## More info
+<!-- ## More info
 
-* [The font tables explained](fonttables.md) `Learn`
+Overall knowledge 
+
+* [The font tables explained](fonttables.md) `Learn` -->
 

--- a/gf-guide/index.md
+++ b/gf-guide/index.md
@@ -54,10 +54,10 @@ Know the particularities about mastering your font project to meet the Google Fo
 * <b>[Variable fonts specifics](variable.md)</b>
   <span style="background-color:#ffd7f1; color:#926b85; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Must Read</span>
 * <b>[Vertical metrics](metrics.md)</b>
-  <span style="background-color:#ffd7f1; color:#926b85; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Must Read</span>
+  <span style="background-color:#ffd7f1; color:#926b85; padding:1px">`Must Read`</span>
 <br><br>
 * [Refining your typeface](refining.md)
-  <span style="background-color:#efefff; color:#74758b; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Learn</span>
+  <span style="background-color:#efefff; color:#74758b; padding:1px; font-family:'Andale Mono'; font-size:0.9em">`Learn`</span>
 * [Outline Quality](outlines.md) 
   <span style="background-color:#efefff; color:#74758b; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Learn</span>
 

--- a/gf-guide/index.md
+++ b/gf-guide/index.md
@@ -31,7 +31,6 @@ To improve and facilitate the open collaboration as well as the publishing proce
   <span style="background-color:#ffd7f1; color:#926b85; padding:1px; font-size:0.9em">`Must Read`</span>
 * <b>[README file](readmefile.md)</b>
   <span style="background-color:#ffd7f1; color:#926b85; padding:1px; font-size:0.9em">`Must Read`</span>
-<br><br>
 * [Maintaining your font repo](maintaining.md) 
   <span style="background-color:#efefff; color:#74758b; padding:1px; font-size:0.9em">`Learn`</span>
 * [Authors and Contributors](authors.md)
@@ -55,7 +54,6 @@ Know the particularities about mastering your font project to meet the Google Fo
    <span style="background-color:#ffd7f1; color:#926b85; padding:1px; font-size:0.9em">`Must Read`</span>
 * <b>[Vertical metrics](metrics.md)</b>
    <span style="background-color:#ffd7f1; color:#926b85; padding:1px; font-size:0.9em">`Must Read`</span>
-<br><br>
 * [Refining your typeface](refining.md)
    <span style="background-color:#efefff; color:#74758b; padding:1px; font-size:0.9em">`Learn`</span>
 * [Outline Quality](outlines.md) 
@@ -69,7 +67,6 @@ Context on the requirements to produce the fonts and get them ready for publishi
    <span style="background-color:#dee0ff; color:#5f6dd1; padding:1px; font-size:0.9em">`Starting Point`</span>
 * <b>[Scalable font production](https://googlefonts.github.io/gf-guide/production.html#scalable-font-production)</b>
    <span style="background-color:#ffd7f1; color:#926b85; padding:1px; font-size:0.9em">`Must Read`</span>
-<br><br>
 * [Build the fonts](build.md) 
    <span style="background-color:#efefff; color:#74758b; padding:1px; font-size:0.9em">`Learn`</span>
 * [QA tools](qa.md) 

--- a/gf-guide/index.md
+++ b/gf-guide/index.md
@@ -4,7 +4,7 @@
 >
 > Therefore, **this documentation is not meant to be read at once**. If you are already familiar with some of the concepts, for example, some people are more empowered with the use of Github please you can skip some chapters and jump to the other bits that you may be looking for. The guidelines have been separated into small bits to facilitate the search of specific informations that you would need at a specific stage of the font production.
 >
-> If you’re a **newcomer** and you want to **contribute** fonts to Google Fonts, whether commissioned or as a voluntary contribution, you should read the chapters marked with `Starting point` and `Must read`. Additional resources are available under the `Learn` label.
+> If you’re a **newcomer** and you want to **contribute** fonts to Google Fonts, whether commissioned or as a voluntary contribution, you should read the chapters marked with `Starting Point` and `Must read`. Additional resources are available under the `Learn` label.
 > 
 > If you are an **experienced** user or are **onboarding** fonts to Google Fonts, the chapters marked with `Team Member` and `Nerd` are for you.
 
@@ -13,69 +13,69 @@
 The most basic concepts, tools, or knowledge you will need to cover to begin contributing with Google Fonts.
 
 * <b>[Libre Font Culture](culture.md)</b>
-  <span style="background-color:#dee0ff; color:#5f6dd1; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Starting Point</span>
+  <span style="background-color:#dee0ff; color:#5f6dd1; padding:1px; font-size:0.9em">`Starting Point`</span>
 * <b>[Required Knowledge](https://googlefonts.github.io/gf-guide/tools.html#required-knowledge)</b>
-  <span style="background-color:#dee0ff; color:#5f6dd1; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Starting Point</span>
+  <span style="background-color:#dee0ff; color:#5f6dd1; padding:1px; font-size:0.9em">`Starting Point`</span>
 * <b>[Setting up a working environment](https://googlefonts.github.io/gf-guide/tools.</b>html#setting-up-a-working-environment)</b>
-  <span style="background-color:#dee0ff; color:#5f6dd1; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Starting Point</span>
+  <span style="background-color:#dee0ff; color:#5f6dd1; padding:1px; font-size:0.9em">`Starting Point`</span>
 * <b>[Installing the required tools](https://googlefonts.github.io/gf-guide/tools.html#installing-the-required-tools)</b>
-  <span style="background-color:#dee0ff; color:#5f6dd1; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Starting Point</span>
+  <span style="background-color:#dee0ff; color:#5f6dd1; padding:1px; font-size:0.9em">`Starting Point`</span>
 * <b>[Hosting projects on Github](hosting.md)</b>
-  <span style="background-color:#dee0ff; color:#5f6dd1; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Starting Point</span>
+  <span style="background-color:#dee0ff; color:#5f6dd1; padding:1px; font-size:0.9em">`Starting Point`</span>
 
 ## The Upstream Repo: administrate your project files
 
 To improve and facilitate the open collaboration as well as the publishing process, we require a specific structure for your files on the GitHub repository.
 
 * <b>[Upstream repository structure](upstream.md)</b>
-  <span style="background-color:#ffd7f1; color:#926b85; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Must Read</span>
+  <span style="background-color:#ffd7f1; color:#926b85; padding:1px; font-size:0.9em">`Must Read`</span>
 * <b>[README file](readmefile.md)</b>
-  <span style="background-color:#ffd7f1; color:#926b85; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Must Read</span>
+  <span style="background-color:#ffd7f1; color:#926b85; padding:1px; font-size:0.9em">`Must Read`</span>
 <br><br>
 * [Maintaining your font repo](maintaining.md) 
-  <span style="background-color:#efefff; color:#74758b; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Learn</span>
+  <span style="background-color:#efefff; color:#74758b; padding:1px; font-size:0.9em">`Learn`</span>
 * [Authors and Contributors](authors.md)
-  <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Template</span>
+  <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-size:0.9em">`Template`</span>
 * [License file](license.md)
-  <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Template</span>
+  <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-size:0.9em">`Template`</span>
 
 ## Pre-production: Getting your fonts ready for GF
 
 Know the particularities about mastering your font project to meet the Google Fonts specifications and get them ready for production.
 
 * <b>[New fonts specifics](https://googlefonts.github.io/gf-guide/onboarding.html#new-fonts)</b>
-  <span style="background-color:#dee0ff; color:#5f6dd1; padding:1px;  font-family:'Andale Mono'; font-size:0.9em">Starting Point</span>
+   <span style="background-color:#dee0ff; color:#5f6dd1; padding:1px; font-size:0.9em">`Starting Point`</span>
 * <b>[Upgrading fonts specifics](https://googlefonts.github.io/gf-guide/onboarding.html#font-upgrades)</b>
-  <span style="background-color:#dee0ff; color:#5f6dd1; padding:1px;  font-family:'Andale Mono'; font-size:0.9em">Starting Point</span>
+   <span style="background-color:#dee0ff; color:#5f6dd1; padding:1px; font-size:0.9em">`Starting Point`</span>
 * <b>[Overall font files requirements](requirements.md)</b>
-  <span style="background-color:#ffd7f1; color:#926b85; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Must Read</span>
+   <span style="background-color:#ffd7f1; color:#926b85; padding:1px; font-size:0.9em">`Must Read`</span>
 * <b>[Static fonts specifics](statics.md)</b>
-  <span style="background-color:#ffd7f1; color:#926b85; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Must Read</span>
+   <span style="background-color:#ffd7f1; color:#926b85; padding:1px; font-size:0.9em">`Must Read`</span>
 * <b>[Variable fonts specifics](variable.md)</b>
-  <span style="background-color:#ffd7f1; color:#926b85; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Must Read</span>
+   <span style="background-color:#ffd7f1; color:#926b85; padding:1px; font-size:0.9em">`Must Read`</span>
 * <b>[Vertical metrics](metrics.md)</b>
-  <span style="background-color:#ffd7f1; color:#926b85; padding:1px">`Must Read`</span>
+   <span style="background-color:#ffd7f1; color:#926b85; padding:1px; font-size:0.9em">`Must Read`</span>
 <br><br>
 * [Refining your typeface](refining.md)
-  <span style="background-color:#efefff; color:#74758b; padding:1px; font-family:'Andale Mono'; font-size:0.9em">`Learn`</span>
+   <span style="background-color:#efefff; color:#74758b; padding:1px; font-size:0.9em">`Learn`</span>
 * [Outline Quality](outlines.md) 
-  <span style="background-color:#efefff; color:#74758b; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Learn</span>
+   <span style="background-color:#efefff; color:#74758b; padding:1px; font-size:0.9em">`Learn`</span>
 
 ## Production: compiling your fonts for GF
 
 Context on the requirements to produce the fonts and get them ready for publishing.
 
 * <b>[Massively distribution implications](https://googlefonts.github.io/gf-guide/production.html#fonts-are-massively-distributed)</b>
-  <span style="background-color:#dee0ff; color:#5f6dd1; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Starting Point</span>
+   <span style="background-color:#dee0ff; color:#5f6dd1; padding:1px; font-size:0.9em">`Starting Point`</span>
 * <b>[Scalable font production](https://googlefonts.github.io/gf-guide/production.html#scalable-font-production)</b>
-  <span style="background-color:#ffd7f1; color:#926b85; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Must Read</span>
+   <span style="background-color:#ffd7f1; color:#926b85; padding:1px; font-size:0.9em">`Must Read`</span>
 <br><br>
 * [Build the fonts](build.md) 
-  <span style="background-color:#efefff; color:#74758b; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Learn</span>
+   <span style="background-color:#efefff; color:#74758b; padding:1px; font-size:0.9em">`Learn`</span>
 * [QA tools](qa.md) 
-  <span style="background-color:#efefff; color:#74758b; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Learn</span>
+   <span style="background-color:#efefff; color:#74758b; padding:1px; font-size:0.9em">`Learn`</span>
 * [Local testing](testing.md) 
-  <span style="background-color:#efefff; color:#74758b; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Learn</span>
+   <span style="background-color:#efefff; color:#74758b; padding:1px; font-size:0.9em">`Learn`</span>
 
 
 ## The google/fonts repository 
@@ -83,7 +83,7 @@ Context on the requirements to produce the fonts and get them ready for publishi
 Details on the Google Fonts `Fonts` repository that host the fonts already included in the Catalogue.
 
 * [google/fonts repository explained](googlefonts.md)
-  <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Nerd</span>
+   <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-size:0.9em">`Nerd`</span>
 
 
 ## Onboarding Fonts to GF
@@ -91,24 +91,24 @@ Details on the Google Fonts `Fonts` repository that host the fonts already inclu
 Advanced content for experienced contributors or Team member with the details on the publishing process.
 
 * [Making a PR to Google Fonts](making-pr.md)
-  <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Nerd</span>
+   <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-size:0.9em">`Nerd`</span>
 * [Package the fonts](package.md) 
-  <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Team Member</span>
+   <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-size:0.9em">`Team Member`</span>
 * [Onboarder workflow guide](onboarder-workflow.md) 
-  <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Team Member</span>
+   <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-size:0.9em">`Team Member`</span>
 * [METADATA file](metadata.md) 
-  <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Team Member</span>
+   <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-size:0.9em">`Team Member`</span>
 * [Description file](description.md)
-  <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Team Member</span>
+   <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-size:0.9em">`Team Member`</span>
 * [Designer Profile](profile.md) 
-  <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Template</span>
+   <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-size:0.9em">`Template`</span>
 * [Promo / Marketing](marketing.md) 
-  <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Template</span>
+   <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-size:0.9em">`Template`</span>
 
 <!-- ## More info
 
 Overall knowledge 
 
 * [The font tables explained](fonttables.md) 
-<span style="background-color:#efefff; color:#74758b; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Learn</span> -->
+   <span style="background-color:#efefff; color:#74758b; padding:1px; font-size:0.9em">`Learn`</span> -->
 

--- a/gf-guide/index.md
+++ b/gf-guide/index.md
@@ -23,9 +23,9 @@ The most basic concepts, tools, or knowledge you will need to cover to begin con
 * <b>[Hosting projects on Github](hosting.md)</b>
   <span style="background-color:#dee0ff; color:#5f6dd1; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Starting Point</span>
 
-## The Upstream Repo: allocate and administrate your project files
+## The Upstream Repo: administrate your project files
 
-To improve and facilitate the open collaborative process as well as the publishing process, we require an specific structure for your files on the GitHub repository.
+To improve and facilitate the open collaboration as well as the publishing process, we require a specific structure for your files on the GitHub repository.
 
 * <b>[Upstream repository structure](upstream.md)</b>
   <span style="background-color:#ffd7f1; color:#926b85; padding:1px; font-family:'Andale Mono'; font-size:0.9em">Must Read</span>

--- a/gf-guide/index.md
+++ b/gf-guide/index.md
@@ -61,7 +61,7 @@ Know the particularities about mastering your font project to meet the Google Fo
 
 ## Production: compiling your fonts for GF
 
-Context on the requirements to produce the fonts and get them ready for publishing.
+Context, requirements, and tools to produce the fonts and get them ready for publishing.
 
 * <b>[Massively distribution implications](https://googlefonts.github.io/gf-guide/production.html#fonts-are-massively-distributed)</b>
    <span style="background-color:#dee0ff; color:#5f6dd1; padding:1px; font-size:0.9em">`Starting Point`</span>
@@ -77,7 +77,7 @@ Context on the requirements to produce the fonts and get them ready for publishi
 
 ## The google/fonts repository 
 
-Details on the Google Fonts `Fonts` repository that host the fonts already included in the Catalogue.
+Details on the `Google Fonts` repository that hosts the fonts projects already included in the Catalogue.
 
 * [google/fonts repository explained](googlefonts.md)
    <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-size:0.9em">`Nerd`</span>
@@ -85,7 +85,7 @@ Details on the Google Fonts `Fonts` repository that host the fonts already inclu
 
 ## Onboarding Fonts to GF
 
-Advanced content for experienced contributors or Team member with the details on the publishing process.
+Advanced content for experienced contributors or Team Members with the details on the publishing process.
 
 * [Making a PR to Google Fonts](making-pr.md)
    <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-size:0.9em">`Nerd`</span>

--- a/gf-guide/index.md
+++ b/gf-guide/index.md
@@ -7,48 +7,47 @@ If you are **onboarding** fonts to Google Fonts, or for very advanced users, the
 
 ## Introduction
 
-* [Google Fonts Guide TL;DR](tldr.md) (*Starting Point*, *2.0*)
-* [Libre Font Culture](culture.md) (*Learn*, *2.0*)
-* [Tools and Dependencies](tools.md) (*Starting Point*, *2.0*)
-* [Hosting projects on Github](hosting.md) (*Learn*, *2.0*)
-* [google/fonts repository explained](googlefonts.md) (*Nerd*, *2.0*)
+* [Google Fonts Guide TL;DR](tldr.md) `Starting Point`
+* [Libre Font Culture](culture.md) `Learn`
+* [Tools and Dependencies](tools.md) `Starting Point`
+* [Hosting projects on Github](hosting.md) `Learn`
+* [google/fonts repository explained](googlefonts.md) `Nerd`
 
 ## Onboarding Fonts to GF
-* [Production requirements](production.md)
-* [Adding & upgrading fonts to Google Fonts](onboarding.md)
-* [Making a PR to Google Fonts](making-pr.md)
-* [Onboarder workflow guide](onboarder-workflow.md)
-* [METADATA file](metadata.md)
-* [Description file](description.md)
-* [Designer Profile](profile.md)
-* [Promo / Marketing](marketing.md)
+* [Production requirements](production.md) `Starting Point`
+* [Adding & upgrading fonts to Google Fonts](onboarding.md) `Starting Point`
+* [Making a PR to Google Fonts](making-pr.md) `Nerd`
+* [Onboarder workflow guide](onboarder-workflow.md) `Team Member`
+* [METADATA file](metadata.md) `Team Member`
+* [Description file](description.md) `Team Member`
+* [Designer Profile](profile.md) `Template`
+* [Promo / Marketing](marketing.md) `Template`
 
 ## The Upstream Repo
 
-* [Upstream repository structure](upstream.md)
-* [README file](readmefile.md)
-* [Authors and Contributors](authors.md)
-* [License file](license.md)
-* [Maintaining your font repo](maintaining.md)
+* [Upstream repository structure](upstream.md) `Must Read`
+* [README file](readmefile.md) `Must Read`
+* [Authors and Contributors](authors.md) `Template`
+* [License file](license.md) `Template`
+* [Maintaining your font repo](maintaining.md) `Learn`
 
 ## Pre-production: Getting your fonts ready for GF
 
-* [Overall font files requirements](requirements.md)
-* [Static fonts specifics](statics.md)
-* [Variable fonts specifics](variable.md)
-* [Vertical metrics](metrics.md)
-* [Refining your typeface](refining.md)
-* [Outline Quality](outlines.md)
-* [Color fonts specifics](colorfonts.md)
+* [Overall font files requirements](requirements.md) `Must Read`
+* [Static fonts specifics](statics.md) `Must Read`
+* [Variable fonts specifics](variable.md) `Must Read`
+* [Vertical metrics](metrics.md) `Must Read`
+* [Refining your typeface](refining.md) `Learn`
+* [Outline Quality](outlines.md) `Learn`
 
 ## More about tools, build, and QA
 
-* [Build the fonts](build.md)
-* [QA tools](qa.md)
-* [Local testing](testing.md)
-* [Package the fonts](package.md)
+* [Build the fonts](build.md) `Nerd`
+* [QA tools](qa.md) `Nerd`
+* [Local testing](testing.md) `Learn`
+* [Package the fonts](package.md) `Team Member`
 
 ## More info
 
-* [The font tables explained](fonttables.md)
+* [The font tables explained](fonttables.md) `Learn`
 

--- a/gf-guide/tldr.md
+++ b/gf-guide/tldr.md
@@ -7,7 +7,7 @@
 <details>
   <summary>Libre Fonts Culture</summary>
 
-  You are contributing to an open-source based platform. It’s important for you to get familiar at least with the basics about [Libre Fonts Culture](culture.md)
+Now that you are contributing to an open-source based platform, it is important for you to get familiar at least with the basics about [Libre Fonts Culture](culture.md)
 </details>
 
 <details>


### PR DESCRIPTION
This PR includes a layout of the content in sections based on the process that an average new user should normally follow to publish their fonts on GF:

1. Getting familiar with the basic needed bits -> *Introduction*
2. Creating/organizing the files on the GH repo, to begin with the process -> *Upstream Repo*
3. Mastering the font files to meet the spec -> *Preproduction*
4. Details on the production requirements and tools needed for it -> *Production*
5. Publishing the fonts, more oriented for experienced and team members -> *Onboarding* 

The formating also includes:

- Single text line to give context for each section contents
- Bold emphasis for `Starting Point` + `Must read` contents
- Ordering from most important (starting and must) to less crucial contents (learn, template, them members)
- Some HTML tags that hopefully will add color to the labels as a visual aid to required bits. 

On GitHub they still look like normal `tags` but they would look different once in HTML pages

Expected result would be:

<img width="1077" alt="Screen Shot 2022-06-01 at 18 42 01" src="https://user-images.githubusercontent.com/48698976/171524324-4d8e348b-08e8-49ea-a5ba-13bad18d9212.png">


