### PR TITLE
Layout proposal

### DIFF
--- a/gf-guide/index.md
+++ b/gf-guide/index.md
@@ -1,27 +1,27 @@
 # Google Fonts Guide
 
 <div style="background-color:#F6F6F6; color:#121212; padding:10px; border-radius: 10px; font-size:1em">
- 🦜 This guide aims to help people to navigate requirements and recommendations to contribute to [Google Fonts](https://fonts.google.com). The contents covered here range from general knowledge to contextualize the <i>what</i> and <i>why</i> of some of the requirements as well as the specifics regarding technical aspects with some suggestions on how to comply with them. It covers different levels of information for both newcomers and more experienced contributors.
+  🦜 This guide aims to help people to navigate requirements and recommendations to contribute to <a href="https://fonts.google.com">Google Fonts</a>. The contents covered here range from general knowledge to contextualize the <i>what</i> and <i>why</i> of some of the requirements as well as the specifics regarding technical aspects with some suggestions on how to comply with them. It covers different levels of information for both newcomers and more experienced contributors.
 
- Therefore, **this documentation is not meant to be read at once**. If you are already familiar with some of the concepts, for example, some people are more empowered with the use of Github please you can skip some chapters and jump to the other bits that you may be looking for. The guidelines have been separated into small bits to facilitate the search of specific informations that you would need at a specific stage of the font production.
+  Therefore, **this documentation is not meant to be read at once**. If you are already familiar with some of the concepts, for example, some people are more empowered with the use of Github please you can skip some chapters and jump to the other bits that you may be looking for. The guidelines have been separated into small bits to facilitate the search of specific informations that you would need at a specific stage of the font production.
 
-If you’re a **newcomer** and you want to **contribute** fonts to Google Fonts, whether commissioned or as a voluntary contribution, you should read the chapters marked with 
-<span style="background-color:#D6F6C1; color:#5D9361; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">start</span> 
-and 
-<span style="background-color:#FFAA89; color:#D83C00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">must_</span>. 
-Additional resources are available under the 
-<span style="background-color:#FFEE99; color:#B28B00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">learn</span> 
-label.
+  If you’re a **newcomer** and you want to **contribute** fonts to Google Fonts, whether commissioned or as a voluntary contribution, you should read the chapters marked with 
+  <span style="background-color:#D6F6C1; color:#5D9361; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">start</span> 
+  and 
+  <span style="background-color:#FFAA89; color:#D83C00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">must_</span>. 
+  Additional resources are available under the 
+  <span style="background-color:#FFEE99; color:#B28B00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">learn</span> 
+  label.
 
-If you are an **experienced** user or are **onboarding** fonts to Google Fonts, the chapters marked with 
-<span style="background-color:#99DDFF; color:#008ACE; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">team_</span> 
-and 
-<span style="background-color:#99DDFF; color:#008ACE; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">nerd_</span> 
-are for you.
+  If you are an **experienced** user or are **onboarding** fonts to Google Fonts, the chapters marked with 
+  <span style="background-color:#99DDFF; color:#008ACE; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">team_</span> 
+  and 
+  <span style="background-color:#99DDFF; color:#008ACE; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">nerd_</span> 
+  are for you.
 
-This guide also provide useful template documents to copy paste in your repository, these are marked with the 
-<span style="background-color:#E5E5E5; color:#6B6B6B; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">templ</span> 
-label.
+  This guide also provide useful template documents to copy paste in your repository, these are marked with the 
+  <span style="background-color:#E5E5E5; color:#6B6B6B; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">templ</span> 
+  label.
 </div>
 
 

--- a/gf-guide/index.md
+++ b/gf-guide/index.md
@@ -73,10 +73,12 @@ Know the particularities about mastering your font project to meet the Google Fo
 * <span style="background-color:#FFAA89; color:#D83C00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">must_</span>
   <b>[Vertical metrics](metrics.md)</b>
 * <span style="background-color:#FFEE99; color:#B28B00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">learn</span>
-  [Refining your typeface](refining.md) 
-* <span style="background-color:#FFEE99; color:#B28B00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">learn</span>
   [Outline Quality](outlines.md) 
-   
+<!--
+* <span style="background-color:#FFEE99; color:#B28B00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">learn</span>
+  [Refining your typeface](refining.md) 
+-->
+
 ## Production: compiling your fonts for GF
 
 Context, requirements, and tools to produce the fonts and get them ready for publishing.

--- a/gf-guide/index.md
+++ b/gf-guide/index.md
@@ -1,111 +1,119 @@
 # Google Fonts Guide
 
-> 🦜 This guide aims to help people to navigate requirements and recommendations to contribute to [Google Fonts](https://fonts.google.com). The contents covered here range from general knowledge to contextualize the _what_ and _why_ of some of the requirements as well as the specifics regarding technical aspects with some suggestions on how to comply with them. It covers different levels of information for both newcomers and more experienced contributors.
->
-> Therefore, **this documentation is not meant to be read at once**. If you are already familiar with some of the concepts, for example, some people are more empowered with the use of Github please you can skip some chapters and jump to the other bits that you may be looking for. The guidelines have been separated into small bits to facilitate the search of specific informations that you would need at a specific stage of the font production.
->
-> If you’re a **newcomer** and you want to **contribute** fonts to Google Fonts, whether commissioned or as a voluntary contribution, you should read the chapters marked with `Starting Point` and `Must read`. Additional resources are available under the `Learn` label.
-> 
-> If you are an **experienced** user or are **onboarding** fonts to Google Fonts, the chapters marked with `Team Member` and `Nerd` are for you.
+<div style="background-color:#F6F6F6; color:#121212; padding:10px; border-radius: 10px; font-size:1em">
+ 🦜 This guide aims to help people to navigate requirements and recommendations to contribute to [Google Fonts](https://fonts.google.com). The contents covered here range from general knowledge to contextualize the <i>what</i> and <i>why</i> of some of the requirements as well as the specifics regarding technical aspects with some suggestions on how to comply with them. It covers different levels of information for both newcomers and more experienced contributors.
+
+ Therefore, **this documentation is not meant to be read at once**. If you are already familiar with some of the concepts, for example, some people are more empowered with the use of Github please you can skip some chapters and jump to the other bits that you may be looking for. The guidelines have been separated into small bits to facilitate the search of specific informations that you would need at a specific stage of the font production.
+
+If you’re a **newcomer** and you want to **contribute** fonts to Google Fonts, whether commissioned or as a voluntary contribution, you should read the chapters marked with `START` and `MUST_`. Additional resources are available under the `LEARN` label.
+
+If you are an **experienced** user or are **onboarding** fonts to Google Fonts, the chapters marked with `TEAM_` and `NERD_` are for you.
+
+This guide also provide useful template documents to copy paste in your repository, these are marked with the `TEMPL` label.
+</div>
+
 
 ## Introduction: getting familiar with the basics
 
 The most basic concepts, tools, or knowledge you will need to cover to begin contributing with Google Fonts.
 
-* <b>[Libre Font Culture](culture.md)</b>
-  <span style="background-color:#dee0ff; color:#5f6dd1; padding:1px; font-size:0.9em">`Starting Point`</span>
-* <b>[Required Knowledge](https://googlefonts.github.io/gf-guide/tools.html#required-knowledge)</b>
-  <span style="background-color:#dee0ff; color:#5f6dd1; padding:1px; font-size:0.9em">`Starting Point`</span>
-* <b>[Setting up a working environment](https://googlefonts.github.io/gf-guide/tools.</b>html#setting-up-a-working-environment)</b>
-  <span style="background-color:#dee0ff; color:#5f6dd1; padding:1px; font-size:0.9em">`Starting Point`</span>
-* <b>[Installing the required tools](https://googlefonts.github.io/gf-guide/tools.html#installing-the-required-tools)</b>
-  <span style="background-color:#dee0ff; color:#5f6dd1; padding:1px; font-size:0.9em">`Starting Point`</span>
-* <b>[Hosting projects on Github](hosting.md)</b>
-  <span style="background-color:#dee0ff; color:#5f6dd1; padding:1px; font-size:0.9em">`Starting Point`</span>
+* <span style="background-color:#dee0ff; color:#5f6dd1; padding:1px; font-size:0.9em">`START`</span>
+  <b>[Libre Font Culture](culture.md)</b>
+* <span style="background-color:#dee0ff; color:#5f6dd1; padding:1px; font-size:0.9em">`START`</span>
+  <b>[Required Knowledge](https://googlefonts.github.io/gf-guide/tools.html#required-knowledge)</b>
+* <span style="background-color:#dee0ff; color:#5f6dd1; padding:1px; font-size:0.9em">`START`</span>
+  <b>[Setting up a working environment](https://googlefonts.github.io/gf-guide/tools.</b>html#setting-up-a-working-environment)</b> 
+* <span style="background-color:#dee0ff; color:#5f6dd1; padding:1px; font-size:0.9em">`START`</span>
+  <b>[Installing the required tools](https://googlefonts.github.io/gf-guide/tools.html#installing-the-required-tools)</b> 
+* <span style="background-color:#FFDF68; color:#EEBB00; padding:1px; font-size:0.9em">`LEARN`</span>
+  [Hosting projects on Github](hosting.md)
 
 ## The Upstream Repo: administrate your project files
 
 To improve and facilitate the open collaboration as well as the publishing process, we require a specific structure for your files on the GitHub repository.
 
-* <b>[Upstream repository structure](upstream.md)</b>
-  <span style="background-color:#ffd7f1; color:#926b85; padding:1px; font-size:0.9em">`Must Read`</span>
-* <b>[README file](readmefile.md)</b>
-  <span style="background-color:#ffd7f1; color:#926b85; padding:1px; font-size:0.9em">`Must Read`</span>
-* [Maintaining your font repo](maintaining.md) 
-  <span style="background-color:#efefff; color:#74758b; padding:1px; font-size:0.9em">`Learn`</span>
-* [Authors and Contributors](authors.md)
-  <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-size:0.9em">`Template`</span>
-* [License file](license.md)
-  <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-size:0.9em">`Template`</span>
+* <span style="background-color:#ffd7f1; color:#926b85; padding:1px; font-size:0.9em">`MUST_`</span>
+  <b>[Upstream repository structure](upstream.md)</b>
+* <span style="background-color:#ffd7f1; color:#926b85; padding:1px; font-size:0.9em">`MUST_`</span>
+  <b>[README file](readmefile.md)</b> 
+* <span style="background-color:#FFDF68; color:#EEBB00; padding:1px; font-size:0.9em">`LEARN`</span>
+  [Maintaining your font repo](maintaining.md) 
+* <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-size:0.9em">`TEMPL`</span>
+  [Authors and Contributors](authors.md)  
+* <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-size:0.9em">`TEMPL`</span>
+   [License file](license.md)
+  
 
 ## Pre-production: Getting your fonts ready for GF
 
 Know the particularities about mastering your font project to meet the Google Fonts specifications and get them ready for production.
 
-* <b>[New fonts specifics](https://googlefonts.github.io/gf-guide/onboarding.html#new-fonts)</b>
-   <span style="background-color:#dee0ff; color:#5f6dd1; padding:1px; font-size:0.9em">`Starting Point`</span>
-* <b>[Upgrading fonts specifics](https://googlefonts.github.io/gf-guide/onboarding.html#font-upgrades)</b>
-   <span style="background-color:#dee0ff; color:#5f6dd1; padding:1px; font-size:0.9em">`Starting Point`</span>
-* <b>[Overall font files requirements](requirements.md)</b>
-   <span style="background-color:#ffd7f1; color:#926b85; padding:1px; font-size:0.9em">`Must Read`</span>
-* <b>[Static fonts specifics](statics.md)</b>
-   <span style="background-color:#ffd7f1; color:#926b85; padding:1px; font-size:0.9em">`Must Read`</span>
-* <b>[Variable fonts specifics](variable.md)</b>
-   <span style="background-color:#ffd7f1; color:#926b85; padding:1px; font-size:0.9em">`Must Read`</span>
-* <b>[Vertical metrics](metrics.md)</b>
-   <span style="background-color:#ffd7f1; color:#926b85; padding:1px; font-size:0.9em">`Must Read`</span>
-* [Refining your typeface](refining.md)
-   <span style="background-color:#efefff; color:#74758b; padding:1px; font-size:0.9em">`Learn`</span>
-* [Outline Quality](outlines.md) 
-   <span style="background-color:#efefff; color:#74758b; padding:1px; font-size:0.9em">`Learn`</span>
-
+* <span style="background-color:#dee0ff; color:#5f6dd1; padding:1px; font-size:0.9em">`START`</span>
+  <b>[New fonts specifics](https://googlefonts.github.io/gf-guide/onboarding.html#new-fonts)</b> 
+* <span style="background-color:#dee0ff; color:#5f6dd1; padding:1px; font-size:0.9em">`START`</span>
+  <b>[Upgrading fonts specifics](https://googlefonts.github.io/gf-guide/onboarding.html#font-upgrades)</b> 
+* <span style="background-color:#ffd7f1; color:#926b85; padding:1px; font-size:0.9em">`MUST_`</span>
+  <b>[Overall font files requirements](requirements.md)</b> 
+* <span style="background-color:#ffd7f1; color:#926b85; padding:1px; font-size:0.9em">`MUST_`</span>
+  <b>[Static fonts specifics](statics.md)</b> 
+* <span style="background-color:#ffd7f1; color:#926b85; padding:1px; font-size:0.9em">`MUST_`</span>
+  <b>[Variable fonts specifics](variable.md)</b>
+* <span style="background-color:#ffd7f1; color:#926b85; padding:1px; font-size:0.9em">`MUST_`</span>
+  <b>[Vertical metrics](metrics.md)</b>
+* <span style="background-color:#FFDF68; color:#EEBB00; padding:1px; font-size:0.9em">`LEARN`</span>
+  [Refining your typeface](refining.md) 
+* <span style="background-color:#FFDF68; color:#EEBB00; padding:1px; font-size:0.9em">`LEARN`</span>
+  [Outline Quality](outlines.md) 
+   
 ## Production: compiling your fonts for GF
 
 Context, requirements, and tools to produce the fonts and get them ready for publishing.
 
-* <b>[Massively distribution implications](https://googlefonts.github.io/gf-guide/production.html#fonts-are-massively-distributed)</b>
-   <span style="background-color:#dee0ff; color:#5f6dd1; padding:1px; font-size:0.9em">`Starting Point`</span>
-* <b>[Scalable font production](https://googlefonts.github.io/gf-guide/production.html#scalable-font-production)</b>
-   <span style="background-color:#ffd7f1; color:#926b85; padding:1px; font-size:0.9em">`Must Read`</span>
-* [Build the fonts](build.md) 
-   <span style="background-color:#efefff; color:#74758b; padding:1px; font-size:0.9em">`Learn`</span>
-* [QA tools](qa.md) 
-   <span style="background-color:#efefff; color:#74758b; padding:1px; font-size:0.9em">`Learn`</span>
-* [Local testing](testing.md) 
-   <span style="background-color:#efefff; color:#74758b; padding:1px; font-size:0.9em">`Learn`</span>
+* <span style="background-color:#dee0ff; color:#5f6dd1; padding:1px; font-size:0.9em">`START`</span>
+  <b>[Massively distribution implications](https://googlefonts.github.io/gf-guide/production.html#fonts-are-massively-distributed)</b>
+* <span style="background-color:#ffd7f1; color:#926b85; padding:1px; font-size:0.9em">`MUST_`</span>
+  <b>[Scalable font production](https://googlefonts.github.io/gf-guide/production.html#scalable-font-production)</b>
+* <span style="background-color:#FFDF68; color:#EEBB00; padding:1px; font-size:0.9em">`LEARN`</span>
+  [Build the fonts](build.md) 
+* <span style="background-color:#FFDF68; color:#EEBB00; padding:1px; font-size:0.9em">`LEARN`</span>
+  [QA tools](qa.md)  
+* <span style="background-color:#FFDF68; color:#EEBB00; padding:1px; font-size:0.9em">`LEARN`</span>
+  [Local testing](testing.md) 
 
 
 ## The google/fonts repository 
 
 Details on the `Google Fonts` repository that hosts the fonts projects already included in the Catalogue.
 
-* [google/fonts repository explained](googlefonts.md)
-   <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-size:0.9em">`Nerd`</span>
+* <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-size:0.9em">`NERD_`</span>
+  [google/fonts repository explained](googlefonts.md)
 
 
 ## Onboarding Fonts to GF
 
-Advanced content for experienced contributors or Team Members with the details on the publishing process.
+Advanced content for experienced contributors or `TEAM_` members with the details on the publishing process.
 
-* [Making a PR to Google Fonts](making-pr.md)
-   <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-size:0.9em">`Nerd`</span>
-* [Package the fonts](package.md) 
-   <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-size:0.9em">`Team Member`</span>
-* [Onboarder workflow guide](onboarder-workflow.md) 
-   <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-size:0.9em">`Team Member`</span>
-* [METADATA file](metadata.md) 
-   <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-size:0.9em">`Team Member`</span>
-* [Description file](description.md)
-   <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-size:0.9em">`Team Member`</span>
-* [Designer Profile](profile.md) 
-   <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-size:0.9em">`Template`</span>
-* [Promo / Marketing](marketing.md) 
-   <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-size:0.9em">`Template`</span>
+* <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-size:0.9em">`NERD_`</span>
+  [Making a PR to Google Fonts](making-pr.md) 
+* <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-size:0.9em">`TEAM_`</span>
+  [Package the fonts](package.md) 
+* <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-size:0.9em">`TEAM_`</span>
+  [Onboarder workflow guide](onboarder-workflow.md) 
+* <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-size:0.9em">`TEAM_`</span>
+  [METADATA file](metadata.md) 
+* <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-size:0.9em">`TEAM_`</span>
+  [Description file](description.md)
+* <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-size:0.9em">`TEMPL`</span>
+  [Designer Profile](profile.md) 
+* <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-size:0.9em">`TEMPL`</span>
+  [Promo / Marketing](marketing.md) 
+   
 
 <!-- ## More info
 
-Overall knowledge 
+Overall knowledge. 
 
-* [The font tables explained](fonttables.md) 
-   <span style="background-color:#efefff; color:#74758b; padding:1px; font-size:0.9em">`Learn`</span> -->
+* <span style="background-color:#FFDF68; color:#EEBB00; padding:1px; font-size:0.9em">`LEARN`</span>
+  [The font tables explained](fonttables.md) 
+-->
 

--- a/gf-guide/index.md
+++ b/gf-guide/index.md
@@ -17,30 +17,30 @@ This guide also provide useful template documents to copy paste in your reposito
 
 The most basic concepts, tools, or knowledge you will need to cover to begin contributing with Google Fonts.
 
-* <span style="background-color:#dee0ff; color:#5f6dd1; padding:1px; font-size:0.9em">`START`</span>
+* <span style="background-color:#B0EAB5; color:#5D9361; padding:1px; font-size:0.9em">`START`</span>
   <b>[Libre Font Culture](culture.md)</b>
-* <span style="background-color:#dee0ff; color:#5f6dd1; padding:1px; font-size:0.9em">`START`</span>
+* <span style="background-color:#B0EAB5; color:#5D9361; padding:1px; font-size:0.9em">`START`</span>
   <b>[Required Knowledge](https://googlefonts.github.io/gf-guide/tools.html#required-knowledge)</b>
-* <span style="background-color:#dee0ff; color:#5f6dd1; padding:1px; font-size:0.9em">`START`</span>
+* <span style="background-color:#B0EAB5; color:#5D9361; padding:1px; font-size:0.9em">`START`</span>
   <b>[Setting up a working environment](https://googlefonts.github.io/gf-guide/tools.</b>html#setting-up-a-working-environment)</b> 
-* <span style="background-color:#dee0ff; color:#5f6dd1; padding:1px; font-size:0.9em">`START`</span>
+* <span style="background-color:#B0EAB5; color:#5D9361; padding:1px; font-size:0.9em">`START`</span>
   <b>[Installing the required tools](https://googlefonts.github.io/gf-guide/tools.html#installing-the-required-tools)</b> 
-* <span style="background-color:#FFDF68; color:#EEBB00; padding:1px; font-size:0.9em">`LEARN`</span>
+* <span style="background-color:#FFEE99; color:#E1B002; padding:1px; font-size:0.9em">`LEARN`</span>
   [Hosting projects on Github](hosting.md)
 
 ## The Upstream Repo: administrate your project files
 
 To improve and facilitate the open collaboration as well as the publishing process, we require a specific structure for your files on the GitHub repository.
 
-* <span style="background-color:#ffd7f1; color:#926b85; padding:1px; font-size:0.9em">`MUST_`</span>
+* <span style="background-color:#FFAA89; color:#D83C00; padding:1px; font-size:0.9em">`MUST_`</span>
   <b>[Upstream repository structure](upstream.md)</b>
-* <span style="background-color:#ffd7f1; color:#926b85; padding:1px; font-size:0.9em">`MUST_`</span>
+* <span style="background-color:#FFAA89; color:#D83C00; padding:1px; font-size:0.9em">`MUST_`</span>
   <b>[README file](readmefile.md)</b> 
-* <span style="background-color:#FFDF68; color:#EEBB00; padding:1px; font-size:0.9em">`LEARN`</span>
+* <span style="background-color:#FFEE99; color:#E1B002; padding:1px; font-size:0.9em">`LEARN`</span>
   [Maintaining your font repo](maintaining.md) 
-* <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-size:0.9em">`TEMPL`</span>
+* <span style="background-color:#E5E5E5; color:#6B6B6B; padding:1px; font-size:0.9em">`TEMPL`</span>
   [Authors and Contributors](authors.md)  
-* <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-size:0.9em">`TEMPL`</span>
+* <span style="background-color:#E5E5E5; color:#6B6B6B; padding:1px; font-size:0.9em">`TEMPL`</span>
    [License file](license.md)
   
 
@@ -48,36 +48,36 @@ To improve and facilitate the open collaboration as well as the publishing proce
 
 Know the particularities about mastering your font project to meet the Google Fonts specifications and get them ready for production.
 
-* <span style="background-color:#dee0ff; color:#5f6dd1; padding:1px; font-size:0.9em">`START`</span>
+* <span style="background-color:#B0EAB5; color:#5D9361; padding:1px; font-size:0.9em">`START`</span>
   <b>[New fonts specifics](https://googlefonts.github.io/gf-guide/onboarding.html#new-fonts)</b> 
-* <span style="background-color:#dee0ff; color:#5f6dd1; padding:1px; font-size:0.9em">`START`</span>
+* <span style="background-color:#B0EAB5; color:#5D9361; padding:1px; font-size:0.9em">`START`</span>
   <b>[Upgrading fonts specifics](https://googlefonts.github.io/gf-guide/onboarding.html#font-upgrades)</b> 
-* <span style="background-color:#ffd7f1; color:#926b85; padding:1px; font-size:0.9em">`MUST_`</span>
+* <span style="background-color:#FFAA89; color:#D83C00; padding:1px; font-size:0.9em">`MUST_`</span>
   <b>[Overall font files requirements](requirements.md)</b> 
-* <span style="background-color:#ffd7f1; color:#926b85; padding:1px; font-size:0.9em">`MUST_`</span>
+* <span style="background-color:#FFAA89; color:#D83C00; padding:1px; font-size:0.9em">`MUST_`</span>
   <b>[Static fonts specifics](statics.md)</b> 
-* <span style="background-color:#ffd7f1; color:#926b85; padding:1px; font-size:0.9em">`MUST_`</span>
+* <span style="background-color:#FFAA89; color:#D83C00; padding:1px; font-size:0.9em">`MUST_`</span>
   <b>[Variable fonts specifics](variable.md)</b>
-* <span style="background-color:#ffd7f1; color:#926b85; padding:1px; font-size:0.9em">`MUST_`</span>
+* <span style="background-color:#FFAA89; color:#D83C00; padding:1px; font-size:0.9em">`MUST_`</span>
   <b>[Vertical metrics](metrics.md)</b>
-* <span style="background-color:#FFDF68; color:#EEBB00; padding:1px; font-size:0.9em">`LEARN`</span>
+* <span style="background-color:#FFEE99; color:#E1B002; padding:1px; font-size:0.9em">`LEARN`</span>
   [Refining your typeface](refining.md) 
-* <span style="background-color:#FFDF68; color:#EEBB00; padding:1px; font-size:0.9em">`LEARN`</span>
+* <span style="background-color:#FFEE99; color:#E1B002; padding:1px; font-size:0.9em">`LEARN`</span>
   [Outline Quality](outlines.md) 
    
 ## Production: compiling your fonts for GF
 
 Context, requirements, and tools to produce the fonts and get them ready for publishing.
 
-* <span style="background-color:#dee0ff; color:#5f6dd1; padding:1px; font-size:0.9em">`START`</span>
+* <span style="background-color:#B0EAB5; color:#5D9361; padding:1px; font-size:0.9em">`START`</span>
   <b>[Massively distribution implications](https://googlefonts.github.io/gf-guide/production.html#fonts-are-massively-distributed)</b>
-* <span style="background-color:#ffd7f1; color:#926b85; padding:1px; font-size:0.9em">`MUST_`</span>
+* <span style="background-color:#FFAA89; color:#D83C00; padding:1px; font-size:0.9em">`MUST_`</span>
   <b>[Scalable font production](https://googlefonts.github.io/gf-guide/production.html#scalable-font-production)</b>
-* <span style="background-color:#FFDF68; color:#EEBB00; padding:1px; font-size:0.9em">`LEARN`</span>
+* <span style="background-color:#FFEE99; color:#E1B002; padding:1px; font-size:0.9em">`LEARN`</span>
   [Build the fonts](build.md) 
-* <span style="background-color:#FFDF68; color:#EEBB00; padding:1px; font-size:0.9em">`LEARN`</span>
+* <span style="background-color:#FFEE99; color:#E1B002; padding:1px; font-size:0.9em">`LEARN`</span>
   [QA tools](qa.md)  
-* <span style="background-color:#FFDF68; color:#EEBB00; padding:1px; font-size:0.9em">`LEARN`</span>
+* <span style="background-color:#FFEE99; color:#E1B002; padding:1px; font-size:0.9em">`LEARN`</span>
   [Local testing](testing.md) 
 
 
@@ -85,7 +85,7 @@ Context, requirements, and tools to produce the fonts and get them ready for pub
 
 Details on the `Google Fonts` repository that hosts the fonts projects already included in the Catalogue.
 
-* <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-size:0.9em">`NERD_`</span>
+* <span style="background-color:#99DDFF; color:#008ACE; padding:1px; font-size:0.9em">`NERD_`</span>
   [google/fonts repository explained](googlefonts.md)
 
 
@@ -93,19 +93,19 @@ Details on the `Google Fonts` repository that hosts the fonts projects already i
 
 Advanced content for experienced contributors or `TEAM_` members with the details on the publishing process.
 
-* <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-size:0.9em">`NERD_`</span>
+* <span style="background-color:#99DDFF; color:#008ACE; padding:1px; font-size:0.9em">`NERD_`</span>
   [Making a PR to Google Fonts](making-pr.md) 
-* <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-size:0.9em">`TEAM_`</span>
+* <span style="background-color:#99DDFF; color:#008ACE; padding:1px; font-size:0.9em">`TEAM_`</span>
   [Package the fonts](package.md) 
-* <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-size:0.9em">`TEAM_`</span>
+* <span style="background-color:#99DDFF; color:#008ACE; padding:1px; font-size:0.9em">`TEAM_`</span>
   [Onboarder workflow guide](onboarder-workflow.md) 
-* <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-size:0.9em">`TEAM_`</span>
+* <span style="background-color:#99DDFF; color:#008ACE; padding:1px; font-size:0.9em">`TEAM_`</span>
   [METADATA file](metadata.md) 
-* <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-size:0.9em">`TEAM_`</span>
+* <span style="background-color:#99DDFF; color:#008ACE; padding:1px; font-size:0.9em">`TEAM_`</span>
   [Description file](description.md)
-* <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-size:0.9em">`TEMPL`</span>
+* <span style="background-color:#E5E5E5; color:#6B6B6B; padding:1px; font-size:0.9em">`TEMPL`</span>
   [Designer Profile](profile.md) 
-* <span style="background-color:#f5f5f5; color:#8e8fa5; padding:1px; font-size:0.9em">`TEMPL`</span>
+* <span style="background-color:#E5E5E5; color:#6B6B6B; padding:1px; font-size:0.9em">`TEMPL`</span>
   [Promo / Marketing](marketing.md) 
    
 
@@ -113,7 +113,7 @@ Advanced content for experienced contributors or `TEAM_` members with the detail
 
 Overall knowledge. 
 
-* <span style="background-color:#FFDF68; color:#EEBB00; padding:1px; font-size:0.9em">`LEARN`</span>
+* <span style="background-color:#FFEE99; color:#E1B002; padding:1px; font-size:0.9em">`LEARN`</span>
   [The font tables explained](fonttables.md) 
 -->
 

--- a/gf-guide/index.md
+++ b/gf-guide/index.md
@@ -6,21 +6,21 @@
  Therefore, **this documentation is not meant to be read at once**. If you are already familiar with some of the concepts, for example, some people are more empowered with the use of Github please you can skip some chapters and jump to the other bits that you may be looking for. The guidelines have been separated into small bits to facilitate the search of specific informations that you would need at a specific stage of the font production.
 
 If you’re a **newcomer** and you want to **contribute** fonts to Google Fonts, whether commissioned or as a voluntary contribution, you should read the chapters marked with 
-<span style="background-color:#D6F6C1; color:#5D9361; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">START</span> 
+<span style="background-color:#D6F6C1; color:#5D9361; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">start</span> 
 and 
-<span style="background-color:#FFAA89; color:#D83C00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">MUST_</span>. 
+<span style="background-color:#FFAA89; color:#D83C00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">must_</span>. 
 Additional resources are available under the 
-<span style="background-color:#FFEE99; color:#B28B00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">LEARN</span> 
+<span style="background-color:#FFEE99; color:#B28B00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">learn</span> 
 label.
 
 If you are an **experienced** user or are **onboarding** fonts to Google Fonts, the chapters marked with 
-<span style="background-color:#99DDFF; color:#008ACE; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">TEAM_</span> 
+<span style="background-color:#99DDFF; color:#008ACE; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">team_</span> 
 and 
-<span style="background-color:#99DDFF; color:#008ACE; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">NERD_</span> 
+<span style="background-color:#99DDFF; color:#008ACE; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">nerd_</span> 
 are for you.
 
 This guide also provide useful template documents to copy paste in your repository, these are marked with the 
-<span style="background-color:#E5E5E5; color:#6B6B6B; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">TEMPL</span> 
+<span style="background-color:#E5E5E5; color:#6B6B6B; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">templ</span> 
 label.
 </div>
 
@@ -29,30 +29,30 @@ label.
 
 The most basic concepts, tools, or knowledge you will need to cover to begin contributing with Google Fonts.
 
-* <span style="background-color:#D6F6C1; color:#5D9361; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">START</span>
+* <span style="background-color:#D6F6C1; color:#5D9361; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">start</span>
   <b>[Libre Font Culture](culture.md)</b>
-* <span style="background-color:#D6F6C1; color:#5D9361; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">START</span>
+* <span style="background-color:#D6F6C1; color:#5D9361; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">start</span>
   <b>[Required Knowledge](https://googlefonts.github.io/gf-guide/tools.html#required-knowledge)</b>
-* <span style="background-color:#D6F6C1; color:#5D9361; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">START</span>
+* <span style="background-color:#D6F6C1; color:#5D9361; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">start</span>
   <b>[Setting up a working environment](https://googlefonts.github.io/gf-guide/tools.</b>html#setting-up-a-working-environment)</b> 
-* <span style="background-color:#D6F6C1; color:#5D9361; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">START</span>
+* <span style="background-color:#D6F6C1; color:#5D9361; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">start</span>
   <b>[Installing the required tools](https://googlefonts.github.io/gf-guide/tools.html#installing-the-required-tools)</b> 
-* <span style="background-color:#FFEE99; color:#B28B00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">LEARN</span>
+* <span style="background-color:#FFEE99; color:#B28B00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">learn</span>
   [Hosting projects on Github](hosting.md)
 
 ## The Upstream Repo: administrate your project files
 
 To improve and facilitate the open collaboration as well as the publishing process, we require a specific structure for your files on the GitHub repository.
 
-* <span style="background-color:#FFAA89; color:#D83C00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">MUST_</span>
+* <span style="background-color:#FFAA89; color:#D83C00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">must_</span>
   <b>[Upstream repository structure](upstream.md)</b>
-* <span style="background-color:#FFAA89; color:#D83C00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">MUST_</span>
+* <span style="background-color:#FFAA89; color:#D83C00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">must_</span>
   <b>[README file](readmefile.md)</b> 
-* <span style="background-color:#FFEE99; color:#B28B00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">LEARN</span>
+* <span style="background-color:#FFEE99; color:#B28B00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">learn</span>
   [Maintaining your font repo](maintaining.md) 
-* <span style="background-color:#E5E5E5; color:#6B6B6B; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">TEMPL</span>
+* <span style="background-color:#E5E5E5; color:#6B6B6B; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">templ</span>
   [Authors and Contributors](authors.md)  
-* <span style="background-color:#E5E5E5; color:#6B6B6B; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">TEMPL</span>
+* <span style="background-color:#E5E5E5; color:#6B6B6B; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">templ</span>
    [License file](license.md)
   
 
@@ -60,36 +60,36 @@ To improve and facilitate the open collaboration as well as the publishing proce
 
 Know the particularities about mastering your font project to meet the Google Fonts specifications and get them ready for production.
 
-* <span style="background-color:#D6F6C1; color:#5D9361; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">START</span>
+* <span style="background-color:#D6F6C1; color:#5D9361; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">start</span>
   <b>[New fonts specifics](https://googlefonts.github.io/gf-guide/onboarding.html#new-fonts)</b> 
-* <span style="background-color:#D6F6C1; color:#5D9361; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">START</span>
+* <span style="background-color:#D6F6C1; color:#5D9361; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">start</span>
   <b>[Upgrading fonts specifics](https://googlefonts.github.io/gf-guide/onboarding.html#font-upgrades)</b> 
-* <span style="background-color:#FFAA89; color:#D83C00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">MUST_</span>
+* <span style="background-color:#FFAA89; color:#D83C00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">must_</span>
   <b>[Overall font files requirements](requirements.md)</b> 
-* <span style="background-color:#FFAA89; color:#D83C00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">MUST_</span>
+* <span style="background-color:#FFAA89; color:#D83C00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">must_</span>
   <b>[Static fonts specifics](statics.md)</b> 
-* <span style="background-color:#FFAA89; color:#D83C00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">MUST_</span>
+* <span style="background-color:#FFAA89; color:#D83C00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">must_</span>
   <b>[Variable fonts specifics](variable.md)</b>
-* <span style="background-color:#FFAA89; color:#D83C00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">MUST_</span>
+* <span style="background-color:#FFAA89; color:#D83C00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">must_</span>
   <b>[Vertical metrics](metrics.md)</b>
-* <span style="background-color:#FFEE99; color:#B28B00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">LEARN</span>
+* <span style="background-color:#FFEE99; color:#B28B00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">learn</span>
   [Refining your typeface](refining.md) 
-* <span style="background-color:#FFEE99; color:#B28B00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">LEARN</span>
+* <span style="background-color:#FFEE99; color:#B28B00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">learn</span>
   [Outline Quality](outlines.md) 
    
 ## Production: compiling your fonts for GF
 
 Context, requirements, and tools to produce the fonts and get them ready for publishing.
 
-* <span style="background-color:#D6F6C1; color:#5D9361; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">START</span>
+* <span style="background-color:#D6F6C1; color:#5D9361; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">start</span>
   <b>[Massively distribution implications](https://googlefonts.github.io/gf-guide/production.html#fonts-are-massively-distributed)</b>
-* <span style="background-color:#FFAA89; color:#D83C00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">MUST_</span>
+* <span style="background-color:#FFAA89; color:#D83C00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">must_</span>
   <b>[Scalable font production](https://googlefonts.github.io/gf-guide/production.html#scalable-font-production)</b>
-* <span style="background-color:#FFEE99; color:#B28B00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">LEARN</span>
+* <span style="background-color:#FFEE99; color:#B28B00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">learn</span>
   [Build the fonts](build.md) 
-* <span style="background-color:#FFEE99; color:#B28B00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">LEARN</span>
+* <span style="background-color:#FFEE99; color:#B28B00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">learn</span>
   [QA tools](qa.md)  
-* <span style="background-color:#FFEE99; color:#B28B00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">LEARN</span>
+* <span style="background-color:#FFEE99; color:#B28B00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">learn</span>
   [Local testing](testing.md) 
 
 
@@ -97,7 +97,7 @@ Context, requirements, and tools to produce the fonts and get them ready for pub
 
 Details on the Google Fonts repository that hosts the fonts projects already included in the Catalogue.
 
-* <span style="background-color:#99DDFF; color:#008ACE; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">NERD_</span>
+* <span style="background-color:#99DDFF; color:#008ACE; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">nerd_</span>
   [google/fonts repository explained](googlefonts.md)
 
 
@@ -105,19 +105,19 @@ Details on the Google Fonts repository that hosts the fonts projects already inc
 
 Advanced content for experienced contributors or team members with the details on the publishing process.
 
-* <span style="background-color:#99DDFF; color:#008ACE; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">NERD_</span>
+* <span style="background-color:#99DDFF; color:#008ACE; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">nerd_</span>
   [Making a PR to Google Fonts](making-pr.md) 
-* <span style="background-color:#99DDFF; color:#008ACE; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">TEAM_</span>
+* <span style="background-color:#99DDFF; color:#008ACE; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">team_</span>
   [Package the fonts](package.md) 
-* <span style="background-color:#99DDFF; color:#008ACE; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">TEAM_</span>
+* <span style="background-color:#99DDFF; color:#008ACE; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">team_</span>
   [Onboarder workflow guide](onboarder-workflow.md) 
-* <span style="background-color:#99DDFF; color:#008ACE; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">TEAM_</span>
+* <span style="background-color:#99DDFF; color:#008ACE; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">team_</span>
   [METADATA file](metadata.md) 
-* <span style="background-color:#99DDFF; color:#008ACE; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">TEAM_</span>
+* <span style="background-color:#99DDFF; color:#008ACE; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">team_</span>
   [Description file](description.md)
-* <span style="background-color:#E5E5E5; color:#6B6B6B; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">TEMPL</span>
+* <span style="background-color:#E5E5E5; color:#6B6B6B; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">templ</span>
   [Designer Profile](profile.md) 
-* <span style="background-color:#E5E5E5; color:#6B6B6B; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">TEMPL</span>
+* <span style="background-color:#E5E5E5; color:#6B6B6B; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">templ</span>
   [Promo / Marketing](marketing.md) 
    
 
@@ -125,7 +125,7 @@ Advanced content for experienced contributors or team members with the details o
 
 Overall knowledge. 
 
-* <span style="background-color:#FFEE99; color:#B28B00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">LEARN</span>
+* <span style="background-color:#FFEE99; color:#B28B00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">learn</span>
   [The font tables explained](fonttables.md) 
 -->
 

--- a/gf-guide/index.md
+++ b/gf-guide/index.md
@@ -5,11 +5,23 @@
 
  Therefore, **this documentation is not meant to be read at once**. If you are already familiar with some of the concepts, for example, some people are more empowered with the use of Github please you can skip some chapters and jump to the other bits that you may be looking for. The guidelines have been separated into small bits to facilitate the search of specific informations that you would need at a specific stage of the font production.
 
-If you’re a **newcomer** and you want to **contribute** fonts to Google Fonts, whether commissioned or as a voluntary contribution, you should read the chapters marked with `START` and `MUST_`. Additional resources are available under the `LEARN` label.
+If you’re a **newcomer** and you want to **contribute** fonts to Google Fonts, whether commissioned or as a voluntary contribution, you should read the chapters marked with 
+<span style="background-color:#D6F6C1; color:#5D9361; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">START</span> 
+and 
+<span style="background-color:#FFAA89; color:#D83C00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">MUST_</span>. 
+Additional resources are available under the 
+<span style="background-color:#FFEE99; color:#B28B00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">LEARN</span> 
+label.
 
-If you are an **experienced** user or are **onboarding** fonts to Google Fonts, the chapters marked with `TEAM_` and `NERD_` are for you.
+If you are an **experienced** user or are **onboarding** fonts to Google Fonts, the chapters marked with 
+<span style="background-color:#99DDFF; color:#008ACE; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">TEAM_</span> 
+and 
+<span style="background-color:#99DDFF; color:#008ACE; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">NERD_</span> 
+are for you.
 
-This guide also provide useful template documents to copy paste in your repository, these are marked with the `TEMPL` label.
+This guide also provide useful template documents to copy paste in your repository, these are marked with the 
+<span style="background-color:#E5E5E5; color:#6B6B6B; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">TEMPL</span> 
+label.
 </div>
 
 
@@ -17,30 +29,30 @@ This guide also provide useful template documents to copy paste in your reposito
 
 The most basic concepts, tools, or knowledge you will need to cover to begin contributing with Google Fonts.
 
-* <span style="background-color:#B0EAB5; color:#5D9361; padding:1px; font-size:0.9em">`START`</span>
+* <span style="background-color:#D6F6C1; color:#5D9361; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">START</span>
   <b>[Libre Font Culture](culture.md)</b>
-* <span style="background-color:#B0EAB5; color:#5D9361; padding:1px; font-size:0.9em">`START`</span>
+* <span style="background-color:#D6F6C1; color:#5D9361; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">START</span>
   <b>[Required Knowledge](https://googlefonts.github.io/gf-guide/tools.html#required-knowledge)</b>
-* <span style="background-color:#B0EAB5; color:#5D9361; padding:1px; font-size:0.9em">`START`</span>
+* <span style="background-color:#D6F6C1; color:#5D9361; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">START</span>
   <b>[Setting up a working environment](https://googlefonts.github.io/gf-guide/tools.</b>html#setting-up-a-working-environment)</b> 
-* <span style="background-color:#B0EAB5; color:#5D9361; padding:1px; font-size:0.9em">`START`</span>
+* <span style="background-color:#D6F6C1; color:#5D9361; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">START</span>
   <b>[Installing the required tools](https://googlefonts.github.io/gf-guide/tools.html#installing-the-required-tools)</b> 
-* <span style="background-color:#FFEE99; color:#E1B002; padding:1px; font-size:0.9em">`LEARN`</span>
+* <span style="background-color:#FFEE99; color:#B28B00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">LEARN</span>
   [Hosting projects on Github](hosting.md)
 
 ## The Upstream Repo: administrate your project files
 
 To improve and facilitate the open collaboration as well as the publishing process, we require a specific structure for your files on the GitHub repository.
 
-* <span style="background-color:#FFAA89; color:#D83C00; padding:1px; font-size:0.9em">`MUST_`</span>
+* <span style="background-color:#FFAA89; color:#D83C00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">MUST_</span>
   <b>[Upstream repository structure](upstream.md)</b>
-* <span style="background-color:#FFAA89; color:#D83C00; padding:1px; font-size:0.9em">`MUST_`</span>
+* <span style="background-color:#FFAA89; color:#D83C00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">MUST_</span>
   <b>[README file](readmefile.md)</b> 
-* <span style="background-color:#FFEE99; color:#E1B002; padding:1px; font-size:0.9em">`LEARN`</span>
+* <span style="background-color:#FFEE99; color:#B28B00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">LEARN</span>
   [Maintaining your font repo](maintaining.md) 
-* <span style="background-color:#E5E5E5; color:#6B6B6B; padding:1px; font-size:0.9em">`TEMPL`</span>
+* <span style="background-color:#E5E5E5; color:#6B6B6B; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">TEMPL</span>
   [Authors and Contributors](authors.md)  
-* <span style="background-color:#E5E5E5; color:#6B6B6B; padding:1px; font-size:0.9em">`TEMPL`</span>
+* <span style="background-color:#E5E5E5; color:#6B6B6B; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">TEMPL</span>
    [License file](license.md)
   
 
@@ -48,64 +60,64 @@ To improve and facilitate the open collaboration as well as the publishing proce
 
 Know the particularities about mastering your font project to meet the Google Fonts specifications and get them ready for production.
 
-* <span style="background-color:#B0EAB5; color:#5D9361; padding:1px; font-size:0.9em">`START`</span>
+* <span style="background-color:#D6F6C1; color:#5D9361; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">START</span>
   <b>[New fonts specifics](https://googlefonts.github.io/gf-guide/onboarding.html#new-fonts)</b> 
-* <span style="background-color:#B0EAB5; color:#5D9361; padding:1px; font-size:0.9em">`START`</span>
+* <span style="background-color:#D6F6C1; color:#5D9361; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">START</span>
   <b>[Upgrading fonts specifics](https://googlefonts.github.io/gf-guide/onboarding.html#font-upgrades)</b> 
-* <span style="background-color:#FFAA89; color:#D83C00; padding:1px; font-size:0.9em">`MUST_`</span>
+* <span style="background-color:#FFAA89; color:#D83C00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">MUST_</span>
   <b>[Overall font files requirements](requirements.md)</b> 
-* <span style="background-color:#FFAA89; color:#D83C00; padding:1px; font-size:0.9em">`MUST_`</span>
+* <span style="background-color:#FFAA89; color:#D83C00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">MUST_</span>
   <b>[Static fonts specifics](statics.md)</b> 
-* <span style="background-color:#FFAA89; color:#D83C00; padding:1px; font-size:0.9em">`MUST_`</span>
+* <span style="background-color:#FFAA89; color:#D83C00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">MUST_</span>
   <b>[Variable fonts specifics](variable.md)</b>
-* <span style="background-color:#FFAA89; color:#D83C00; padding:1px; font-size:0.9em">`MUST_`</span>
+* <span style="background-color:#FFAA89; color:#D83C00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">MUST_</span>
   <b>[Vertical metrics](metrics.md)</b>
-* <span style="background-color:#FFEE99; color:#E1B002; padding:1px; font-size:0.9em">`LEARN`</span>
+* <span style="background-color:#FFEE99; color:#B28B00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">LEARN</span>
   [Refining your typeface](refining.md) 
-* <span style="background-color:#FFEE99; color:#E1B002; padding:1px; font-size:0.9em">`LEARN`</span>
+* <span style="background-color:#FFEE99; color:#B28B00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">LEARN</span>
   [Outline Quality](outlines.md) 
    
 ## Production: compiling your fonts for GF
 
 Context, requirements, and tools to produce the fonts and get them ready for publishing.
 
-* <span style="background-color:#B0EAB5; color:#5D9361; padding:1px; font-size:0.9em">`START`</span>
+* <span style="background-color:#D6F6C1; color:#5D9361; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">START</span>
   <b>[Massively distribution implications](https://googlefonts.github.io/gf-guide/production.html#fonts-are-massively-distributed)</b>
-* <span style="background-color:#FFAA89; color:#D83C00; padding:1px; font-size:0.9em">`MUST_`</span>
+* <span style="background-color:#FFAA89; color:#D83C00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">MUST_</span>
   <b>[Scalable font production](https://googlefonts.github.io/gf-guide/production.html#scalable-font-production)</b>
-* <span style="background-color:#FFEE99; color:#E1B002; padding:1px; font-size:0.9em">`LEARN`</span>
+* <span style="background-color:#FFEE99; color:#B28B00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">LEARN</span>
   [Build the fonts](build.md) 
-* <span style="background-color:#FFEE99; color:#E1B002; padding:1px; font-size:0.9em">`LEARN`</span>
+* <span style="background-color:#FFEE99; color:#B28B00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">LEARN</span>
   [QA tools](qa.md)  
-* <span style="background-color:#FFEE99; color:#E1B002; padding:1px; font-size:0.9em">`LEARN`</span>
+* <span style="background-color:#FFEE99; color:#B28B00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">LEARN</span>
   [Local testing](testing.md) 
 
 
 ## The google/fonts repository 
 
-Details on the `Google Fonts` repository that hosts the fonts projects already included in the Catalogue.
+Details on the Google Fonts repository that hosts the fonts projects already included in the Catalogue.
 
-* <span style="background-color:#99DDFF; color:#008ACE; padding:1px; font-size:0.9em">`NERD_`</span>
+* <span style="background-color:#99DDFF; color:#008ACE; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">NERD_</span>
   [google/fonts repository explained](googlefonts.md)
 
 
 ## Onboarding Fonts to GF
 
-Advanced content for experienced contributors or `TEAM_` members with the details on the publishing process.
+Advanced content for experienced contributors or team members with the details on the publishing process.
 
-* <span style="background-color:#99DDFF; color:#008ACE; padding:1px; font-size:0.9em">`NERD_`</span>
+* <span style="background-color:#99DDFF; color:#008ACE; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">NERD_</span>
   [Making a PR to Google Fonts](making-pr.md) 
-* <span style="background-color:#99DDFF; color:#008ACE; padding:1px; font-size:0.9em">`TEAM_`</span>
+* <span style="background-color:#99DDFF; color:#008ACE; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">TEAM_</span>
   [Package the fonts](package.md) 
-* <span style="background-color:#99DDFF; color:#008ACE; padding:1px; font-size:0.9em">`TEAM_`</span>
+* <span style="background-color:#99DDFF; color:#008ACE; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">TEAM_</span>
   [Onboarder workflow guide](onboarder-workflow.md) 
-* <span style="background-color:#99DDFF; color:#008ACE; padding:1px; font-size:0.9em">`TEAM_`</span>
+* <span style="background-color:#99DDFF; color:#008ACE; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">TEAM_</span>
   [METADATA file](metadata.md) 
-* <span style="background-color:#99DDFF; color:#008ACE; padding:1px; font-size:0.9em">`TEAM_`</span>
+* <span style="background-color:#99DDFF; color:#008ACE; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">TEAM_</span>
   [Description file](description.md)
-* <span style="background-color:#E5E5E5; color:#6B6B6B; padding:1px; font-size:0.9em">`TEMPL`</span>
+* <span style="background-color:#E5E5E5; color:#6B6B6B; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">TEMPL</span>
   [Designer Profile](profile.md) 
-* <span style="background-color:#E5E5E5; color:#6B6B6B; padding:1px; font-size:0.9em">`TEMPL`</span>
+* <span style="background-color:#E5E5E5; color:#6B6B6B; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">TEMPL</span>
   [Promo / Marketing](marketing.md) 
    
 
@@ -113,7 +125,7 @@ Advanced content for experienced contributors or `TEAM_` members with the detail
 
 Overall knowledge. 
 
-* <span style="background-color:#FFEE99; color:#E1B002; padding:1px; font-size:0.9em">`LEARN`</span>
+* <span style="background-color:#FFEE99; color:#B28B00; padding:2px; border-radius: 2px; font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;">LEARN</span>
   [The font tables explained](fonttables.md) 
 -->
 


### PR DESCRIPTION
- changed label names so they are the same width and can be put before the title
- chose more contrasted colours
- Added a grey block for the call out
- Propose "hosting projects on github" as `learn` instead of `start`
- green colour may be too bright though

Should look like this in html:

<img width="651" alt="Capture d’écran 2022-06-02 à 13 12 16" src="https://user-images.githubusercontent.com/12222436/171617183-b15825fe-d7a7-497e-a1a0-b6f34e4e20a1.png">

<img width="799" alt="Capture d’écran 2022-06-02 à 13 10 28" src="https://user-images.githubusercontent.com/12222436/171616921-77d8366e-c6c5-4538-b8ac-83e9fc64f03b.png">

cc @vv-monsalve 
