### PR TITLE
fix typo in config key

### DIFF
--- a/gf-guide/build.md
+++ b/gf-guide/build.md
@@ -171,7 +171,7 @@ sources:
 axisOrder:
     - wght
     - ital
-FamilyName: "Font Name"
+familyName: "Font Name"
 ```
 
 GF only needs `TTF` fonts, so you can avoid building OTF as well by adding:


### PR DESCRIPTION
`familyName` should not have a capital `F`, or it breaks the build