### PR TITLE
Fix incorrect gftools qa install command on gf-guide tools page

### DIFF
--- a/gf-guide/tools.md
+++ b/gf-guide/tools.md
@@ -176,7 +176,7 @@ brew install cairo freetype harfbuzz pkg-config
 Finally, you can install `gftools qa`:
 
 ``` code
-pip install gftools[qa]
+pip install 'gftools[qa]'
 ```
 
 Run `gftools qa --help` to have an overview of the usage of the tool.


### PR DESCRIPTION
In the gf-guide tools page [gftools qa](https://googlefonts.github.io/gf-guide/tools.html#gftools-qa) section, there are instructions for installing `gftools qa` that don't match what is in the gftools documentation.

This is what is there now:
```
pip install gftools[qa]
```
This is what is suggested in the [gftools docs](https://github.com/googlefonts/gftools#tool-installation):
```
pip install 'gftools[qa]'
```
On MacOS 12.5.1, running `pip install gftools[qa]` gives me an error:
```
zsh: no matches found: gftools[qa]
```
But running `pip install 'gftools[qa]'` works as expected

This PR changes the command in the docs to `pip install 'gftools[qa]'`.