### PR TITLE
Drafted and corrected chapters related to QA

### DIFF
--- a/gf-guide/index.md
+++ b/gf-guide/index.md
@@ -88,12 +88,12 @@ Context, requirements, and tools to produce the fonts and get them ready for pub
   <b>[Massively distribution implications](https://googlefonts.github.io/gf-guide/production.html#fonts-are-massively-distributed)</b>
 * <mark class="green"><b>must&rarr;</b></mark>
   <b>[Scalable font production](https://googlefonts.github.io/gf-guide/production.html#scalable-font-production)</b>
-* <mark class="green"><b>must&rarr;</b></mark>
-  [QA - Local testing](testing.md) 
 * <mark class="yellow">learn</mark>
   [Build the fonts](build.md) 
 * <mark class="yellow">learn</mark>
-  [QA tools](qa.md)  
+  [QA tools](qa.md)
+* <mark class="yellow">learn</mark>
+  [Local testing](testing.md)   
 
 
 ## The google/fonts repository 
@@ -113,11 +113,13 @@ Advanced content for experienced contributors or team members with the details o
 * <mark class="brown">team&nbsp;</mark>
   [Package the fonts](package.md) 
 * <mark class="brown">team&nbsp;</mark>
-  [Onboarder workflow guide](onboarder-workflow.md) 
-* <mark class="brown">team&nbsp;</mark>
   [METADATA file](metadata.md) 
 * <mark class="brown">team&nbsp;</mark>
   [Description file](description.md)
+* <mark class="brown">team&nbsp;</mark>
+  [Onboarder workflow guide](onboarder-workflow.md)
+* <mark class="brown">team&nbsp;</mark>
+  [Reviewing PRs and sandbox](sandbox.md)  
 * <mark class="grey">templ</mark>
   [Designer Profile](profile.md) 
 * <mark class="grey">templ</mark>

--- a/gf-guide/qa.md
+++ b/gf-guide/qa.md
@@ -1,3 +1,127 @@
-# QA tools
-## Gftools QA
-## Fontbakery
+<link href="style.css" rel="stylesheet">
+
+<a href="./index"><button class="button button-i">&larr; GF Guide Index</button></a>
+
+# Quality Assurance Tools
+{:.no_toc}
+
+<div class="callout">
+
+🐯 This chapter aims to guide designers to have a more automated approach of their binaries quality assurance.
+<br><br>
+We recommend you install all the tools in a virtual environment, to avoid conflict between packages. Further information is detailed in the <a href="./tools">Tools and Dependencies section</a>. 
+<br><br>
+For the rest of this chapter, it would be better if you have basic knowledge of:
+<ul>
+  <li>Using the command line interface</li>
+  <li>Installing python packages</li>
+</ul>
+
+</div>
+
+<div class="context-reading">
+    Background reading:<br>
+    <mark class="blue">start</mark> <a href="./tools" style="font-weight:bold">Tools and Dependencies</a>
+    <br>
+    <mark class="green"><b>must&rarr;</b></mark> <a href="./requirements" style="font-weight:bold">Overall font files requirements</a>
+    <br>
+    <mark class="yellow">learn</mark> <a href="./build" style="font-weight:bold">Build the fonts</a> 
+    <br>
+
+</div>
+
+## Table of contents
+{:.no_toc}
+* TOC goes here
+{:toc}
+
+## Checking the font tabes
+
+Sentence that explain why you would want to check font tables.
+
+-   [TTX]() open xml file, a human readible version of the font tables;
+-   [Font table viewer]() to turn the UFOs into FontTools objects;
+-   [DTL OT Master]() to aslo edit them.
+
+
+## Proofing with `gftools gen-html`
+
+Sentence that explains that gftools allows to proof your binaries + generate screenshots from different browsers
+
+Run `gftools gen-html proof --help` or `gftools gen-html diff --help` to see the available options.
+
+Explain here how it is customisable.
+
+## Checking with Fontbakery
+
+Brief description of fontbakery
+Explain the different profiles and the log levels.
+
+Log levels:
+- PASS
+- INFO
+- WARN
+- FAIL
+
+Main profiles:
+- Universal
+- Adobe
+- Google Fonts
+
+`check-googlefonts` contains all the check from Universal and Adobe, in addition to vendore specific checks that would only apply to fonts which gets published on Google Fonts. Often users complain of inapropriate fails, but remember that a FAIL for the googlefonts profile may be only specific to Google Fonts API, not all environments.
+
+`fontbakery check-googlefonts -l WARN --succinct --ghmarkdown report.md`
+
+Run `fontbakery [profile] --help` to see all the commands.
+
+Some foundries created their own profile to have vendor-specific checks. This is the case of Fontwerk and Font Bureau, and you could do it too with a little bit of python skill!
+
+### gftools qa
+
+`gftools qa` wraps `gftools gen-html` and `fontbakery`.
+
+`gftools qa -f *.ttf -a -o ~/Desktop/font_QA`
+add `-gfb` if you want to have a diff with previous published version on Google Fonts. 
+
+Add note that images are only available to team members.
+
+------------------------------------------------------------------------
+
+## Useful links
+
+- [Fontbakery's documentation](https://font-bakery.readthedocs.io/en/stable/)
+- [Microsoft's font validator](https://github.com/microsoft/Font-Validator) is the official font checking tools for Microsoft environement.
+
+<div id="col1">
+    <b>Testing web pages:</b>
+    <ul>
+      <li><a href="https://wakamaifondue.com/" target="_blank">Wakamai Fondue</a></li>
+      <li><a href="https://fontdrop.info/" target="_blank">FontDrop</a></li>
+      <li><a href="https://www.axis-praxis.org/specimens/__DEFAULT__" target="_blank">Axis-Praxis</a> 
+      and <a href="https://www.axis-praxis.org/samsa/" target="_blank">Samsa</a></li>
+      <li><a href="http://www.rosaliewagner.com/font-testing/index.php" target="_blank">Impallari Testing Pages</a></li>
+      <li><a href="https://dinamodarkroom.com/gauntlet/" target="_blank">Dinamo Font Gautlet</a></li>
+      <li><a href="https://typetools.typenetwork.com" target="_blank">Type Network’s Tools</a></li>
+      <li><a href="https://idiotproofed.com/" target="_blank">Idiot Proof</a></li>
+      <li><a href="https://www.fontspecimen.com/" target="_blank">Monotype’s interactive font specimen</a></li>
+    </ul>
+</div>
+
+  <div id="col2">
+    <b>Testing apps:</b>
+    <ul>
+      <li><a href="https://www.fontmaster.nl/otmaster.html" target="_blank">DTL OT Master</a></li>
+      <li><a href="https://glyphsapp.com/tools/fonttableviewer" target="_blank">Font table viewer</a></li>
+      <li><a href="https://github.com/silnrsi/fontproof" target="_blank">Fontproof</a> (still in development)</li>
+      <li><a href="https://fontgoggles.org/" target="_blank">FontGoggles</a></li>
+    </ul>
+  </div>
+
+<div class="next-reading">
+    Further reading:<br>
+    <mark class="yellow">learn</mark> <a href="./testing" style="font-weight:bold">Local Testing</a>
+    <br>
+    <mark class="yellow">learn</mark> <a href="./outlines" style="font-weight:bold">Outline quality</a>
+    <br>
+    <mark class="yellow">learn</mark> <a href="./diacritics" style="font-weight:bold">Diacritics requirements</a>
+</div>

--- a/gf-guide/sandbox.md
+++ b/gf-guide/sandbox.md
@@ -1,0 +1,148 @@
+<link href="style.css" rel="stylesheet">
+
+<a href="./index"><button class="button button-i">&larr; GF Guide Index</button></a>
+
+# Reviewing PRs and Sandbox
+{:.no_toc}
+
+<div class="callout">
+
+🐯 This chapter aims to share the validation process of a font from the moment it is in a google/fonts PR. To fix issues you will need to know about the other related repository: the Axis Registry, Glyphsets and Lang. You need to know this entire documentation. You need to communicate with the internal engineer team. 
+
+</div>
+
+<div class="context-reading">
+    Background reading:<br>
+    <mark class="yellow">learn</mark> <a href="./build" style="font-weight:bold">QA Tools</a> 
+    <br>
+    <mark class="brown">team&nbsp;</mark> <a href="./requirements" style="font-weight:bold">Onboarder workflow guide</a>
+    <br>
+    <mark class="brown">team&nbsp;</mark> <a href="./requirements" style="font-weight:bold">METADATA file</a>
+    <br>
+    <mark class="brown">team&nbsp;</mark> <a href="./requirements" style="font-weight:bold">Description file</a>
+</div>
+
+## Table of contents
+{:.no_toc}
+* TOC goes here
+{:toc}
+
+## Before merging a PR
+### Right panel
+- There are at least 2 labels: ready for review + new/upgrade/small fix. 
+  If upgrade; an orange label. 
+  If complex script: green label.
+- PR is in traffic jam
+- Issue is linked
+
+### Fontbakery report
+- No fails
+- No easy-to-fix warns
+
+### Changed files
+**METADATA.pb**
+- Has all necessary subsets
+- If noto: has languages
+- If complex script: has primary script
+- If optical size axis: check default or override
+- Correct designer name
+- Correct category
+- URL is consistent with description and License
+
+**OFL.txt**
+- Consistent github URL with METADATA.pb and Description
+
+**Upstream.yml**
+- If Noto: article is linked
+
+**Description**
+- No typos
+- Respect the rules (3rd person etc.)
+- URL is consistent with Licence and METADATA.pb
+
+### Checks (download artifacts)
+**Diffenator**
+
+**Diffbrowser**
+
+## If pass
+- Add "to sandbox label", remove "ready for review" and merge.
+- Add font to the to_sandbox list.
+
+## If issue
+- Report the issue in comment of the PR
+- Add appropriate label ("need confirmation", "regression", "needs upstream resolutuon" etc.)
+- Review again after corrective commit happen
+
+
+## Checking in Sandbox
+
+-   Making sure the font was pushed
+-   To check if the font behave correctly
+-   Double checking previous QA before sending to prod. Most problems could be avoided with thorough QA before merging, but errors can happen.
+
+### Home page
+
+-   No Tofu
+-   The proper Primary script is displayed
+
+### Specimen
+
+-   Primary script is displayed first
+-   No tofu
+-   All expected instances (every 100) are displayed and look okay
+-   Any kind of weirdness
+-   Font style matches category
+
+### Type Tester
+
+-   No tofu
+-   All axes work
+-   No interpolation issue on the few glyphs displayed
+
+### Glyphs
+
+-   Primary script first
+-   Latin style matches the primary script style
+
+### About&License
+
+-   Not empty
+-   No typos
+-   Correct bios
+-   No missing elements (image, URL, etc)
+
+### Download button
+
+-   Package is downloadable
+-   Font version is the expected one
+
+### If pass
+- Remove "to sandbox", add "to production"
+- Add font to `to_production` list
+
+### If issue
+- Add "blocked" and "in sandbox", remove "to sandbox"
+- report in comment of PR
+- re-open issue
+
+## Checking in prod
+
+- Quicly recheck just like in sandbox
+- Check it is the proper version
+- Add “live” to PR and remove “to prod”
+
+
+
+------------------------------------------------------------------------
+
+## Useful links
+
+- 
+
+<div class="next-reading">
+    Further reading:<br>
+    <mark class="grey">templ</mark> <a href="./testing" style="font-weight:bold">Promo/Marketing</a>
+    <br>
+
+</div>

--- a/gf-guide/testing.md
+++ b/gf-guide/testing.md
@@ -172,7 +172,6 @@ What to check:
     <ul>
       <li><a href="https://wakamaifondue.com/" target="_blank">Wakamai Fondue</a></li>
       <li><a href="https://fontdrop.info/" target="_blank">FontDrop</a></li>
-      <li><a href="https://fontgoggles.org/" target="_blank">FontGoggles</a></li>
       <li><a href="https://www.axis-praxis.org/specimens/__DEFAULT__" target="_blank">Axis-Praxis</a> 
       and <a href="https://www.axis-praxis.org/samsa/" target="_blank">Samsa</a></li>
       <li><a href="http://www.rosaliewagner.com/font-testing/index.php" target="_blank">Impallari Testing Pages</a></li>
@@ -189,6 +188,7 @@ What to check:
       <li><a href="https://www.fontmaster.nl/otmaster.html" target="_blank">DTL OT Master</a></li>
       <li><a href="https://glyphsapp.com/tools/fonttableviewer" target="_blank">Font table viewer</a></li>
       <li><a href="https://github.com/silnrsi/fontproof" target="_blank">Fontproof</a> (still in development)</li>
+      <li><a href="https://fontgoggles.org/" target="_blank">FontGoggles</a></li>
     </ul>
   </div>
 </div>


### PR DESCRIPTION
- created server qa page
- added stuff in the QA Tools chapters
- updated index

Still a drafting, but there is: 
- structure
- all html stuff 

We should probably merge as if to have an actual overview of the articles cause it is obviously unreadable like this.
I also suggest to go back to "learn" for the Local Testing to be more consistent with the other QA related articles.

@vv-monsalve 