### PR TITLE
Fix mismatched virtual environment names in tools page

### DIFF
--- a/gf-guide/tools.md
+++ b/gf-guide/tools.md
@@ -99,7 +99,7 @@ It is strongly suggested to create and work under a [Python Virtual Environment]
     python3 -m venv myenv
     ```
 
-    The last part of the command is the name you would like to give to the virtual environment. Usually, it is only `venv`, or `env` if you specifically want to differentiate it from the Python Module "venv" name.
+    The last part of the command is the name you would like to give to the virtual environment. Usually, it is only `venv`, or `myenv` if you specifically want to differentiate it from the Python Module "venv" name.
 2.  Once you have created your virtual environment, you need to **activate** it.
 
     On Unix or macOS run:
@@ -111,16 +111,16 @@ It is strongly suggested to create and work under a [Python Virtual Environment]
     On Windows:
 
     ``` code
-    env\Scripts\activate.bat
+    myenv\Scripts\activate.bat
     ```
 3.  After you have activated the virtual environment, the command prompt will display the name of the virtual environment that you are using in parentheses:
 
     ``` code
-    (env) userName directoryName $
+    (myenv) userName directoryName $
     ```
-3.  To deactivate the virtual env, just type `deactivate`. Note that closing the Terminal window will also deactivate the environment, and you will have to reactivate it every time you want to work on your project.
+3.  To deactivate the virtual environment, just type `deactivate`. Note that closing the Terminal window will also deactivate the environment, and you will have to reactivate it every time you want to work on your project.
 
-You can install as many venvs as you want; in each project directory or your user home directory if you intend to use the same venv for all your projects. Command-line tools often have settings to run a command automatically when a new window opens; you could activate one venv this way and avoid having to type it every time.
+You can install as many virtual environments as you want; in each project directory or your user home directory if you intend to use the same virtual environment for all your projects. Command-line tools often have settings to run a command automatically when a new window opens; you could activate one virtual environment this way and avoid having to type it every time.
 
 It is *not* recommended to instal virtual environments in clouds, drives, dropbox, etc.
 


### PR DESCRIPTION
Commit [0ace6a0](https://github.com/googlefonts/googlefonts.github.io/commit/0ace6a09f48b84aec81d57de9a4f033a4a6d15d1) changed `source env/bin/activate` to `source myenv/bin/activate` but left the old `env` in some other parts of the tools section. I changed everything to `myenv` to make it less confusing. 

I also replaced "venv" with "virtual environment" in the text a few times for clarity.