### PR TITLE
Formatting the lang article + linked info

### DIFF
--- a/gf-guide/googlefonts.md
+++ b/gf-guide/googlefonts.md
@@ -7,7 +7,7 @@
 
 <div class="callout">
 
-🦉 <a href="https://github.com/google/fonts">google/fonts</a> is the GitHub repository that is used as a staging area to upload font families to <a href="https://fonts.google.com/">Google Fonts</a>. 
+🦉 <a href="https://github.com/google/fonts" target="_blank">google/fonts</a> is the GitHub repository that is used as a staging area to upload font families to <a href="https://fonts.google.com/" target="_blank">Google Fonts</a>. 
 <br><br>
 Once your project is ready, and you are sure it meets all the font and production requirements; as well as you have located your files in a GitHub repository that follows the required structure, then the definitive step to contributing your font to Google Fonts is to submit it as a Pull Request to google/fonts repository.
 <br><br>

--- a/gf-guide/lang.md
+++ b/gf-guide/lang.md
@@ -3,8 +3,23 @@
 <a href="./index"><button class="button button-i">&larr; GF Guide Index</button></a>
 
 # Lang Metadata System
+{:.no_toc}
 
-The foundation for the *lang metadata system* is defined in the [`googlefonts/lang`](https://github.com/googlefonts/lang) repo
+<div class="callout">
+🦜 <a href="https://github.com/googlefonts/lang" target="_blank">googlefonts/lang</a> is the GitHub repository that defines the foundation for the *lang metadata system* 
+<br><br>
+This section specifies the main concepts of the system and provides information on how if influences the displaying of the font in the Catalog.
+</div>
+
+<div class="context-reading">
+    Background reading:<br>
+    <mark class="brown">team&nbsp;</mark> <a href="./metadata">METADATA file</a>
+</div>
+
+## Table of contents
+{:.no_toc}
+* TOC goes here
+{:toc}
 
 ## Constructs
 

--- a/gf-guide/metadata.md
+++ b/gf-guide/metadata.md
@@ -371,4 +371,6 @@ archive_url: "https://github.com/username/projectname/releases/download/v2.200/p
     <mark class="grey">templ</mark> <a href="./license">License file</a>
     <br>
     <mark class="grey">templ</mark> <a href="./authors">Authors and Contributors</a>
+    <br>
+    <mark class="purple">nerd&nbsp;</mark> <a href="./lang">Lang repo</a>
 </div>


### PR DESCRIPTION
This PR gives the lang section the GF-Guide formatting.

@nathan-williams  I've added a callout div that aims to introduce users to the section's contents, following the text used in [google/fonts repo](https://googlefonts.github.io/gf-guide/googlefonts.html). I added a small line there, but perhaps you would like to provide expanded details on it.

Also, the `unicode_sections` link is not working. Could you please add the URL you meant to link?

