### PR TITLE
diacritics: use lookupflag for soft dotted example

### DIFF
--- a/gf-guide/diacritics.md
+++ b/gf-guide/diacritics.md
@@ -177,9 +177,8 @@ In a font with a small Latin set the `ccmp` feature code can have the following 
 ```code
 lookup ccmp_soft_dotted {
     @CombiningTopAccents = [acutecomb brevecomb caroncomb circumflexcomb dieresiscomb dotaccentcomb gravecomb macroncomb ringcomb tildecomb];
-    @CombiningNonTopAccents = [cedillacomb ogonekcomb];
+    lookupflag UseMarkFilteringSet @CombiningTopAccents
     sub [i j]' @CombiningTopAccents by [idotless jdotless];
-    sub [i j]' @CombiningNonTopAccents @CombiningTopAccents by [idotless jdotless];
 } ccmp_soft_dotted;
 ```
 
@@ -190,9 +189,8 @@ In a font with a larger Latin glyph set and Cyrillic glyph set, after creating t
 ```code
 lookup ccmp_soft_dotted {
     @CombiningTopAccents = [acutecomb brevecomb caroncomb circumflexcomb dieresiscomb dotaccentcomb gravecomb macroncomb ringcomb tildecomb];
-    @CombiningNonTopAccents = [cedillacomb dotbelowcomb ogonekcomb tildebelowcomb];
+    lookupflag UseMarkFilteringSet @CombiningTopAccents
     sub [i j idotbelow iogonek itildebelow istroke jstroke i-cy je-cy]' @CombiningTopAccents by [idotless jdotless idotless_dotbelowcomb idotless_ogonekcomb idotless_tildebelowcomb istroke.dotless jstroke.dotless idotless jdotless];
-    sub [i j idotbelow iogonek itildebelow istroke jstroke i-cy je-cy]' @CombiningNonTopAccents @CombiningTopAccents by [idotless jdotless idotless_dotbelowcomb idotless_ogonekcomb idotless_tildebelowcomb istroke.dotless jstroke.dotless idotless jdotless];
 } ccmp_soft_dotted;
 ```
 


### PR DESCRIPTION
Replaces lookup code following @simoncozens’s recommendation to use `lookupflag UseMarkFilteringSet @CombiningTopAccents` instead of context with `@CombiningNonTopAccents`.