### PR TITLE
Updating VM policy

### DIFF
--- a/gf-guide/diacritics.md
+++ b/gf-guide/diacritics.md
@@ -138,8 +138,8 @@ Combining marks would be listed like this in the GDEF table:
 
 In some languages like Vietnamese, marks are made of the combination of two other marks known as *stacked diacritics*. In such cases, a combining mark could also act as the 'base' glyph of another mark, and therefore, it would need more than one anchor. For example, in the `brevecomb_acutecomb`, the `brevecomb` mark would have one `_top` anchor to be attached to a base letter, plus a `top` one to attach other marks to it; in this case, the `acutecomb`.
 
-- Distance between marks should also be consistent with the font. The stacked diacritic should be perceived as a unity that forms a whole with the base letter.
-- Again, by ensuring to include right anchor with consistent names will contribute to the correct setting and functioning of the `mkmk` feature in the `GPOS` table.
+- The distance between marks is usually tight and should be consistent with the font. The stacked diacritic should be seen as a unit with the base letter. Smaller shapes than the stand-alone marks can be used to ensure visual balance, especially in capital letters. It is crucial to make sure that these marks are not too high or heavy.
+- Again, by ensuring to include the right anchors with consistent names will contribute to the correct setting and functioning of the `mkmk` feature in the `GPOS` table.
 - Automatic aligment enabled would also be recommended here to avoid placing stacked diacritics manually in the accented glyphs.
 
 ### Soft dotted glyphs

--- a/gf-guide/diacritics.md
+++ b/gf-guide/diacritics.md
@@ -36,7 +36,7 @@ This guide will give users an overview introduction to diacritics both from a de
 - **In Latin script, it is expected that all marks share the same distance to the base letter.** For particular cases like script fonts where the x-height could vary, marks should at least appear to be at the same optical distance to the base letter.
 - **Idiosyncratic or decorative diacritics have given way to more universal or neutral forms.**
 - **Ensure creating all the combining marks required for the languages the font are supporting**, as well as the so-called "Legacy Marks". ([See below](#legacy--spacing-marks).) Google Fonts requires at least the GF Latin Core as the minimum set for a font addressing the Latin script. Please read more about our <a href="https://googlefonts.github.io/gf-guide/requirements.html#glyphsets">Glyphsets</a>.
-- **Create a set of marks for capital letters** To properly display uppercase letters with diacritics, a separate set of `.case` marks should be created. These marks should be designed with adjustments to size, height, or slope and are typically wider, shorter, and flatter than their lowercase counterparts so they use less vertical space avoiding collisions with above text lines. These adjustments are particularly relevant for languages like Vietnamese that require stacked diacritics.
+- **Create a set of marks for capital letters** to properly display uppercase letters with diacritics, a separate set of `.case` marks should be created. These marks should be designed with adjustments to size, height, or slope and are typically wider, shorter, and flatter than their lowercase counterparts so they use less vertical space, avoiding collisions with above text lines. These adjustments are particularly relevant for languages like Vietnamese that require stacked diacritics.
 
 **Examples of what to avoid** *- critical cases*
    <figure>
@@ -139,7 +139,7 @@ Combining marks would be listed like this in the GDEF table:
 In some languages like Vietnamese, marks are made of the combination of two other marks known as *stacked diacritics*. In such cases, a combining mark could also act as the 'base' glyph of another mark, and therefore, it would need more than one anchor. For example, in the `brevecomb_acutecomb`, the `brevecomb` mark would have one `_top` anchor to be attached to a base letter, plus a `top` one to attach other marks to it; in this case, the `acutecomb`.
 
 - The distance between marks is usually tight and should be consistent with the font. The stacked diacritic should be seen as a unit with the base letter. Smaller shapes than the stand-alone marks can be used to ensure visual balance, especially in capital letters. It is crucial to make sure that these marks are not too high or heavy.
-- Again, by ensuring to include the right anchors with consistent names will contribute to the correct setting and functioning of the `mkmk` feature in the `GPOS` table.
+- Again, including the correct anchors with consistent names will ensure the `mkmk` feature in the `GPOS` table.
 - Automatic aligment enabled would also be recommended here to avoid placing stacked diacritics manually in the accented glyphs.
 
 ### Soft dotted glyphs

--- a/gf-guide/diacritics.md
+++ b/gf-guide/diacritics.md
@@ -36,7 +36,7 @@ This guide will give users an overview introduction to diacritics both from a de
 - **In Latin script, it is expected that all marks share the same distance to the base letter.** For particular cases like script fonts where the x-height could vary, marks should at least appear to be at the same optical distance to the base letter.
 - **Idiosyncratic or decorative diacritics have given way to more universal or neutral forms.**
 - **Ensure creating all the combining marks required for the languages the font are supporting**, as well as the so-called "Legacy Marks". ([See below](#legacy--spacing-marks).) Google Fonts requires at least the GF Latin Core as the minimum set for a font addressing the Latin script. Please read more about our <a href="https://googlefonts.github.io/gf-guide/requirements.html#glyphsets">Glyphsets</a>.
-- **Usually, the design of the diacritics needs to be adjusted in size or slope to work better with the uppercase letters**. So ideally there should be at least two sets of diacritics: lowercase and uppercase marks. (e.g. `acutecomb` and `acutecomb.case`)
+- **Create a set of marks for capital letters** To properly display uppercase letters with diacritics, a separate set of `.case` marks should be created. These marks should be designed with adjustments to size, height, or slope and are typically wider, shorter, and flatter than their lowercase counterparts so they use less vertical space avoiding collisions with above text lines. These adjustments are particularly relevant for languages like Vietnamese that require stacked diacritics.
 
 **Examples of what to avoid** *- critical cases*
    <figure>

--- a/gf-guide/metrics.md
+++ b/gf-guide/metrics.md
@@ -150,27 +150,27 @@ Expected result: vertical metrics should be around 130% of UPM. Anything greater
 A new Latin family has the following qualities:
 
 -   UPM is `1000`
--   `yMax` of tallest `A breve acute` in the familly (bold for this example) = `940`
--   `yMin` of deepest a-z letter (`g` bold in this family) = `235`
--   Caps height (`H`or `Z` bbox height) = `730`
--   Family's `yMax = 1116` (Bold `A breve hookabove` for this family)
--   Family's `yMin = 320` (ExtraLight `c cedilla` for this family)
+-   `yMax` of tallest `A breve acute` in the familly (bold for this example) = `1000`
+-   `yMin` of deepest a-z letter (`g` bold in this family) = `210`
+-   Caps height (`H`or `Z` bbox height) = `697`
+-   Family's `yMax = 1000` (Black `A breve hookabove` for this family)
+-   Family's `yMin = -260` (ExtraLight `c cedilla` for this family)
 
 1.  Set the default values, following the schema above:
 
 ``` code
-typoAscender = 965 # (UPM * 1.2 - CapsHeight) / 2 + CapsHeight which is greater than Agrave, perfect.
-typoDescender = -235 # (UPM * 1.2 - CapsHeight) / 2 which is equal to deepest letterform
+typoAscender = 1000 # which is matches tallets `A breve acute` in the family.
+typoDescender = -303 # an equal or similar value added to the Caps Height which is greater than deepest letterform.
 typoLineGap = 0
-hheaAscender = 965 # typoAscender
-hheaDescender = -235 # typoDescender
+hheaAscender = 1000 # typoAscender
+hheaDescender = -303 # typoDescender
 hheaLineGap = 0 # typoLineGap
 winAscent = 1116 # Font bbox yMax
 winDescent = 320 # *absolute value* of Font bbox yMin ie. a positive integer
 ```
 
 1.  Be sure to copy these same metric values to all of the masters in the family
-2.  Enable `Use_Typo_Metrics`
+2.  Be sure to enable `Use_Typo_Metrics`
 
 ### 2. Recalculating the vertical metrics for an upgraded family
 
@@ -235,7 +235,7 @@ The Typo Metrics need to inherit the v1.000 Win values. The WinAscent and WinDes
 2.  Repeat process for each weight/style if values are not unique in v1.000
 3.  Enable Use_Typo_Metrics
 
-If the font was previously hosted on [fonts.google.com](http://fonts.google.com/), you can test the upgraded vertical metrics visually match by using [GF Regression](https://github.com/googlefonts/gfregression). You can also use gftools gen-html with the command `gftools gen-html diff --font-before font1.ttf --font-after font2.ttf` if you want to compare two fonts locally.
+If the font is already hosted on [fonts.google.com](http://fonts.google.com/), you can test the upgraded vertical metrics visually match by using [diffenator2](https://github.com/googlefonts/diffenator2) with the command `diffenator2 diff -fb font1.ttf -fa font2.ttf -o out_dir` where `-fb` stands for `--fonts-before` and `-fa` for `--fonts-after`.
 
 ## CJK Vertical Metrics
 
@@ -270,7 +270,7 @@ Our decision to follow the Adobe schema was based on Dr. Ken Lunde’s comments 
 -   [Show Vertical Metrics](https://github.com/mekkablue/ShowVerticalMetrics) plug-in in GlyphsApp
 -   Mekkablue’s [Vertical Metrics Manager](https://github.com/mekkablue/Glyphs-Scripts/blob/master/Font%20Info/Vertical%20Metrics%20Manager.py)
 -   [Impallari/testing](https://github.com/impallari/Font-Testing-Page): Font tester which has no css line-height property set ([live site](http://cyreal.org/Font-Testing-Page))
--   [GF Regression](https://github.com/googlefonts/gfregression): Check local fonts against currently hosted versions on [fonts.google.com](http://fonts.google.com/)
+-   [Diffenator2](https://github.com/googlefonts/diffenator2): Create diffing docs to compare local updated fonts against currently hosted versions on [fonts.google.com](http://fonts.google.com/)
 
 <!-- <div class="next-reading">
     Further reading:<br>

--- a/gf-guide/metrics.md
+++ b/gf-guide/metrics.md
@@ -31,11 +31,21 @@ Please note that the first metrics guidelines referred to in this guide are Lati
 
 The following rules apply to all new font families, and should be enforced to upgraded font families when possible.
 
-**1. Vertical metrics must not be calculated by the font editor automatically.**
+#### 1. Vertical metrics must not be calculated by the font editor automatically
 
 GF doesn't want this because they all do it differently.
 
-**2. The following vertical metric parameters must be set for each font in a family.**
+#### 2. Vertical metrics must be consistent across a family.
+
+Each font in a family must share the same vertical metric values.
+
+This rule can be avoided if a font is being upgraded and previously had inconsistent family metrics. If this is the case, the aim should be to visually match the line spacing of each font, but fix any clipping issues caused by incorrect `WinAscent`, `WinDescent` values.
+
+#### 3. If the family is being updated, the line height must visually match the previous release
+
+Some applications do not allow users to control the line height/leading of their fonts. Word processors and text editors are common culprits. It is essential their documents do not reflow.
+
+##### 4. The following vertical metric parameters must be set for each font in a family
 
 | Ms Spec ttf spec        | Glyphs.app Master customParameter | FontLab                | ufo3 fontinfo.plist      |
 |-------------------------|-----------------------------------|------------------------|--------------------------|
@@ -50,13 +60,15 @@ GF doesn't want this because they all do it differently.
 
 *For brevity, we will refer to the 3 sets of metrics as* `Typo`*,* `Hhea`*,* `Win`*.*
 
-**3. Vertical metrics must be consistent across a family.**
+##### 5. [Use_Typo_Metrics](https://www.microsoft.com/typography/otspec/os2.htm#fss)** **must be enabled
 
-Each font in a family must share the same vertical metric values.
+This will force MS Applications to use the `Typo` values instead of the `Win` values for line spacing. By doing this, we can freely set the `Win` values to avoid clipping and control the line height with the `Typo` values. It has the added benefit of future line height compatibility. When a new script is added, we simply change the `Win` values to the new `yMin` and `yMax`, without needing to worry if the line height have changed. Note that the `Use_Typo_Metric` flag is also called `fsSelection bit 7 `(related to how it is set in the OS/2 table).
 
-This rule can be avoided if a font is being upgraded and previously had inconsistent family metrics. If this is the case, the aim should be to visually match the line spacing of each font, but fix any clipping issues caused by incorrect `WinAscent`, `WinDescent` values.
+-   In Glyphs.app, set `Use_Typo_Metrics` custom parameter to `true` in the **Font** tab of **Font Info**.
+-   In RoboFont, this is under **Font Info \> OpenType \> OS/2 Table \> fsSelection \> USE_TYPO_METRICS**.
+-   In the OS/2 table: `<fsSelection value="00000000 10000000"/>`
 
-**4. WinAscent and WinDescent values must be the same as the family's tallest/deepest yMin and yMax bounding box values.**
+#### 6. WinAscent and WinDescent values must be the same as the family's tallest/deepest yMin and yMax bounding box values
 
 The Microsoft [OpenType specification](https://www.microsoft.com/typography/otspec/os2.htm#wa). Recommends the following:
 
@@ -66,37 +78,25 @@ The Microsoft [OpenType specification](https://www.microsoft.com/typography/otsp
 
 By changing these values, the line height will be increased in MS applications. This is can lead to very loose line heights if the bounding box is exceedingly tall. This mainly occurs in families featuring Vietnamese, Devanagari and Arabic or other tall scripts. To counteract this, we enable the [Use Typo Metrics](https://www.microsoft.com/typography/otspec/os2.htm#fss) flag and set the `Typo` values to match the previous `Win` values. By swapping the sets, we should retain the previous line heights in Windows as well as remove the clipping.
 
-**5.** **[Use_Typo_Metrics](https://www.microsoft.com/typography/otspec/os2.htm#fss)** **must be enabled.**
-
-This will force MS Applications to use the `Typo` values instead of the `Win` values for line spacing. By doing this, we can freely set the `Win` values to avoid clipping and control the line height with the `Typo` values. It has the added benefit of future line height compatibility. When a new script is added, we simply change the `Win` values to the new `yMin` and `yMax`, without needing to worry if the line height have changed. Note that the `Use_Typo_Metric` flag is also called `fsSelection bit 7 `(related to how it is set in the OS/2 table).
-
--   In Glyphs.app, set `Use_Typo_Metrics` custom parameter to `true` in the **Font** tab of **Font Info**.
--   In RoboFont, this is under **Font Info \> OpenType \> OS/2 Table \> fsSelection \> USE_TYPO_METRICS**.
--   In the OS/2 table: `<fsSelection value="00000000 10000000"/>`
-
-**6. If the family is being updated, the line height must visually match the previous release.**
-
-Some applications do not allow users to control the line height/leading of their fonts. Word processors and text editors are common culprits. It is essential their documents do not reflow.
-
-**7. Hhea and Typo metrics should be equal.**
+#### 7. Hhea and Typo metrics should be equal
 
 `Hhea` metrics are used in macOS, whilst Microsoft uses `Typo` when `Use_Typo_Metrics` is enabled. They should ideally be identical.
 
 This rule can be avoided if a font is being upgraded and previously had inconsistent values.
 
-**8. LineGap values must be 0.**
+## 8. LineGap values must be 0
 
 The `LineGap` value is a space added to the line height created by the union of the `(typo/hhea)Ascender` and `(typo/hhea)Descender`. It is handled differently according to the environment. This leading value will be added above the text line in most desktop apps. It will be shared above *and* under in web browsers, and ignored in Windows if `Use_Typo_Metrics` is disabled. For better linespacing consistency across platforms, `(typo/hhea)LineGap` values must be `0`.
 
-**9. Uppercases should be centered if the font’s primary script has uppercases letterforms such as Latin, Greek and Cyrillic.**
+#### 9. Uppercases should be centered if the font’s primary script has uppercases letterforms such as Latin, Greek and Cyrillic
 
 Web designers will thank you if you managed to have the same space above and under capitals: `typoAscender - CapsHeight = abs(typoDescender)`. It will make easier for them the setting of padding in buttons for example.
 
-**10. typo/hheaAscender value should be greater than Agrave's yMax when it makes sense.**
+#### 10. typo/hheaAscender value should be greater than Agrave's yMax when it makes sense
 
 Some Mac applications such as TextEdit will position the first line of text by, either, using the height of the `A grave`, or by using the font’s `hheaAscender` (whichever is taller). To keep the positioning consistent across a family, we require that the `hheaAscender` is greater than the tallest `A grave` in the family. See this issue for further info, <https://github.com/googlefonts/fontbakery/issues/3170>.
 
-**11. The sum of the font’s vertical metric values (absolute) should be 20-30% greater than the font’s UPM.**
+#### 11. The sum of the font’s vertical metric values (absolute) should be 20-30% greater than the font’s UPM
 
 By default, DTP applications such as Indesign will set the line height to be 20% greater than the font’s size (10pt size / 12pt leading). For consistency, we recommend setting the vertical metric values so their sum is in a similar range, for example:
 

--- a/gf-guide/metrics.md
+++ b/gf-guide/metrics.md
@@ -159,8 +159,8 @@ A new Latin family has the following qualities:
 1.  Set the default values, following the schema above:
 
 ``` code
-typoAscender = 1015 # which matches tallets `A breve acute` in the family and is ≈ [(UPM * 1.3 - CapsHeight) / 2] + CapsHeight
-typoDescender = -315 # an equal or similar value added to the Caps Height to leave them centeered in the line, and is greater than deepest letterform.
+typoAscender = 1015 # which matches tallest `A breve acute` in the family and is ≈ [(UPM * 1.3 - CapsHeight) / 2] + CapsHeight
+typoDescender = -315 # an equal or similar value added to the Caps Height to leave them centered in the line, and is greater than deepest letterform.
 typoLineGap = 0
 hheaAscender = 1015 # typoAscender
 hheaDescender = -315 # typoDescender

--- a/gf-guide/metrics.md
+++ b/gf-guide/metrics.md
@@ -33,7 +33,7 @@ The following rules apply to all new font families, and should be enforced to up
 
 #### 1. Vertical metrics must not be calculated by the font editor automatically
 
-GF doesn't want this because they all do it differently.
+It is an overall best practice. But also, since in GF we have settled out our specific schema that prioritizes optimal performance in different usage scenarios, while also allowing for the possibility of future upgrades, such as expanded language support, avoiding regressions.
 
 #### 2. Vertical metrics must be consistent across a family.
 

--- a/gf-guide/metrics.md
+++ b/gf-guide/metrics.md
@@ -33,7 +33,7 @@ The following rules apply to all new font families, and should be enforced to up
 
 #### 1. Vertical metrics must not be calculated by the font editor automatically
 
-It is an overall best practice. But also, since in GF we have settled out our specific schema that prioritizes optimal performance in different usage scenarios, while also allowing for the possibility of future upgrades, such as expanded language support, avoiding regressions.
+This is an overall best practice in design. When defining line spacing, it's important to strike a balance between legibility and avoiding overlapping letters. At GF, we have established a specific system that prioritizes optimal performance for various situations, while still leaving room for future update improvements like adding more languages without causing regressions. 
 
 #### 2. Vertical metrics must be consistent across a family.
 
@@ -94,12 +94,12 @@ Web designers will thank you if you managed to have the same space above and und
 
 #### 10. typo/hheaAscender value should leave open room for stacked diacritics.
 
-Our minimal required Glyphset for any new family is GF Latin Core, which includes Vietnamese support. Following recent tests to confirm our VM policies, we now require that the typo/hheaAscender be equal to or slightly higher than `A breve acute`. To guarantee uniform positioning across the entire font family, you must use the tallest `A breve acute` as the reference point.
+Following recent tests to confirm our VM policies, we now require that the typo/hheaAscender be equal to `A breve acute`. For families with multiple weights you must use the tallest `A breve acute` (in e.g., the Black master) as the reference point to guarantee uniform positioning across the entire font family.
 
-Even if, for any particular reason, the font does not currently support Vietnamese yet, we strongly suggest estimating the ascenders value foreseeing this glyph height for two main reasons
+Even if the font does not support Vietnamese yet, we strongly suggest estimating the ascenders value foreseeing the `A breve acute` height based two main reasons:
 
-- Once the font is published, it is not possible to modify the vertical metric values. By implementing the above approach, we can keep the option of updating the font in the future to support additional languages.
-- Certain Mac applications, including TextEdit, determine the height of the first line of text by either the `A grave` height or the font's `hheaAscender`, whichever is taller (for additional information on this topic, please refer to this issue: <https://github.com/googlefonts/fontbakery/issues/3170>). So using the suggested `A breve acute` glyph height will prevent clipping in such applications.
+- Once the font is published, it is not possible to modify the vertical metric values. By implementing the above approach, we can keep the option of updating the font in the future to support additional languages like Vietnamese.
+- Certain Mac applications, including TextEdit, determine the height of the first line of text by either the `A grave` height or the font's `hheaAscender`, whichever is taller (for additional information on this topic, please refer to this issue: <https://github.com/googlefonts/fontbakery/issues/3170>). So `Agrave` is a required minimum, and `Abreveacute` is a strongly recommended minimum.
 
 #### 11. The sum of the font’s vertical metric values (absolute) should be 20-30% greater than the font’s UPM
 
@@ -121,9 +121,9 @@ Exceptions are usually made if the font’s primary script isn’t Latin, Greek 
 
 Please keep in mind that this calculation is to be set according to the specificities of each font.
 
--   The 120% suggested above is for compatibility with DTP apps. Still, it can often be too tight if your font covers more languages than basic Latin, Greek, and Cyrillic, or if you have a particular design with short ascenders.  
--   Please pay careful attention to the overall design of diacritic marks, especially the [stacked diacritics](https://googlefonts.github.io/gf-guide/diacritics.html#stacked-diacritics). This way you ensure the ascenders value is not unnecessarily high. 
--   Google Fonts is trying to push designers to include proper support of the mark-to-mark feature allowing combination of diacritics and display of non-encoded accented glyphs. Pay attention to your anchor placement so that, if you combine breve and acute for example, you don't end up with a severe interline glyph clashing. 
+-   The 120% suggested above is for compatibility with DTP apps (like InDesign automatic alignment ratio). Still, it can often be too tight if your font covers more languages than basic Latin, Greek, and Cyrillic, or if you have a particular design with short ascenders.  
+-   Please pay careful attention to the overall design of diacritic marks, especially the [stacked diacritics](https://googlefonts.github.io/gf-guide/diacritics.html#stacked-diacritics). This way you ensure the ascenders value is not unnecessarily high. You could also determine an ideal line spacing and then draw the diacritics accordingly or adapt them to it.
+-   Google Fonts is trying to push designers to include proper support of the [mark-to-mark](https://googlefonts.github.io/gf-guide/diacritics.html#the-glyph-positioning-gpos-table) feature allowing combination of diacritics and display of non-encoded accented glyphs. Pay attention to your anchor placement so that, if you combine breve and acute for example, you don't end up with a severe interline glyph clashing. 
 
 
 ## Concrete cases:
@@ -150,23 +150,23 @@ Expected result: vertical metrics should be around 130% of UPM. Anything greater
 A new Latin family has the following qualities:
 
 -   UPM is `1000`
--   `yMax` of tallest `A breve acute` in the familly (bold for this example) = `1000`
+-   `yMax` of tallest `A breve acute` in the familly (black for this example) = `1015`
 -   `yMin` of deepest a-z letter (`g` bold in this family) = `210`
--   Caps height (`H`or `Z` bbox height) = `697`
--   Family's `yMax = 1000` (Black `A breve hookabove` for this family)
--   Family's `yMin = -260` (ExtraLight `c cedilla` for this family)
+-   Caps height (`H`or `Z` bbox height) = `700`
+-   Family's `yMax = 1116` (Black `A breve hookabove` for this family)
+-   Family's `yMin = -260` (Black `c cedilla` for this family)
 
 1.  Set the default values, following the schema above:
 
 ``` code
-typoAscender = 1000 # which is matches tallets `A breve acute` in the family.
-typoDescender = -303 # an equal or similar value added to the Caps Height which is greater than deepest letterform.
+typoAscender = 1015 # which matches tallets `A breve acute` in the family and is ≈ [(UPM * 1.3 - CapsHeight) / 2] + CapsHeight
+typoDescender = -315 # an equal or similar value added to the Caps Height to leave them centeered in the line, and is greater than deepest letterform.
 typoLineGap = 0
-hheaAscender = 1000 # typoAscender
-hheaDescender = -303 # typoDescender
+hheaAscender = 1015 # typoAscender
+hheaDescender = -315 # typoDescender
 hheaLineGap = 0 # typoLineGap
 winAscent = 1116 # Font bbox yMax
-winDescent = 320 # *absolute value* of Font bbox yMin ie. a positive integer
+winDescent = 315 # *absolute value* of Font bbox yMin ie. a positive integer
 ```
 
 1.  Be sure to copy these same metric values to all of the masters in the family

--- a/gf-guide/metrics.md
+++ b/gf-guide/metrics.md
@@ -171,6 +171,7 @@ winDescent = 315 # *absolute value* of Font bbox yMin ie. a positive integer
 
 1.  Be sure to copy these same metric values to all of the masters in the family
 2.  Be sure to enable `Use_Typo_Metrics`
+3.  If working on GlyphsApp, you can add the "EditView Line Height" parameter in font info and set it up to UPM*1.3 (so 1300 if your UPM value is 1000). This allows you to view your line spacing at the glyph view window.
 
 ### 2. Recalculating the vertical metrics for an upgraded family
 

--- a/gf-guide/metrics.md
+++ b/gf-guide/metrics.md
@@ -121,12 +121,10 @@ Exceptions are usually made if the font’s primary script isn’t Latin, Greek 
 
 Please keep in mind that this calculation is to be set according to the specificities of each font.
 
--   The 120% suggested above is for compatibility with DTP apps. Still, it can often be too tight if your font covers more languages than basic Latin, Greek, and Cyrillic, or if you have a particular design with short ascenders.
--   The choice of the `Agrave` is purely based on the behaviour of some applications, it is not based on some general rules of design.
--   Google Fonts is trying to push designers to include proper support of the mark-to-mark feature allowing combination of diacritics and display of non-encoded accented glyphs. Pay attention to your anchor placement so that, if you combine breve and acute for example, you don't end up with a severe interline glyph clashing. Or adapt your vertical metrics with a certain measure, to find the best compromise.
--   Google Fonts wishes to update fonts to expand glyhpsets, and therefore language support, and therefore accessibility. If your intention is to have, for example, Vietnamese coverage or Thai script in a next update, you can already anticipate the vertical metrics to avoid regressions later.
+-   The 120% suggested above is for compatibility with DTP apps. Still, it can often be too tight if your font covers more languages than basic Latin, Greek, and Cyrillic, or if you have a particular design with short ascenders.  
+-   Please pay careful attention to the overall design of diacritic marks, especially the [stacked diacritics](https://googlefonts.github.io/gf-guide/diacritics.html#stacked-diacritics). This way you ensure the ascenders value is not unnecessarily high. 
+-   Google Fonts is trying to push designers to include proper support of the mark-to-mark feature allowing combination of diacritics and display of non-encoded accented glyphs. Pay attention to your anchor placement so that, if you combine breve and acute for example, you don't end up with a severe interline glyph clashing. 
 
-<!-- For more info about the relationship between diacritics and line height, you can read this document: (to do: link Viviana's doc). -->
 
 ## Concrete cases:
 
@@ -139,20 +137,20 @@ Setting vertical metrics usually falls into the following two categories:
 
 Set these values to be the same across all masters to ensure that output instances have equal vertical metrics:
 
--   `typoAscender` and `hheaAscender` set higher than `À`
+-   `typoAscender` and `hheaAscender` set higher than `Ắ`
 -   `typoLineGap` and `hheaLineGap` set to `0`
--   `typoDescender` and `hheaDescender` set lower than the deepest descender of the primary script.
+-   `typoDescender` and `hheaDescender` set to visually leave Caps height centered in the line, but lower than the deepest descender of the primary script.
 -   `winAscent` and `winDecent` set to `yMax` and `yMin` (absolute highest and lowest point in the font)
 -   `use_typo_metrics` is enabled
 
-Expected result: vertical metrics should be around 120-130% of UPM. Anything greater, and the metrics may look too loose.
+Expected result: vertical metrics should be around 130% of UPM. Anything greater, and the metrics may look too loose.
 
 **Example**
 
 A new Latin family has the following qualities:
 
 -   UPM is `1000`
--   `yMax` of tallest `A grave` in the familly (bold for this example) = `940`
+-   `yMax` of tallest `A breve acute` in the familly (bold for this example) = `940`
 -   `yMin` of deepest a-z letter (`g` bold in this family) = `235`
 -   Caps height (`H`or `Z` bbox height) = `730`
 -   Family's `yMax = 1116` (Bold `A breve hookabove` for this family)

--- a/gf-guide/metrics.md
+++ b/gf-guide/metrics.md
@@ -33,11 +33,11 @@ The following rules apply to all new font families, and should be enforced to up
 
 #### 1. Vertical metrics must not be calculated by the font editor automatically
 
-This is an overall best practice in design. When defining line spacing, it's important to strike a balance between legibility and avoiding overlapping letters. At GF, we have established a specific system that prioritizes optimal performance for various situations, while still leaving room for future update improvements like adding more languages without causing regressions. 
+This is an overall best practice in design. When defining line spacing, it's important to strike a balance between legibility and avoiding overlapping letters. At Google Fonts, we have established a specific system that prioritizes optimal performance for various situations while still leaving room for future update improvements, like adding more languages without causing regressions. 
 
 #### 2. Vertical metrics must be consistent across a family.
 
-Each font in a family must share the same vertical metric values.
+Each font in a family must share the same vertical metrics values.
 
 This rule can be avoided if a font is being upgraded and previously had inconsistent family metrics. If this is the case, the aim should be to visually match the line spacing of each font, but fix any clipping issues caused by incorrect `WinAscent`, `WinDescent` values.
 
@@ -62,7 +62,7 @@ Some applications do not allow users to control the line height/leading of their
 
 ##### 5. [Use_Typo_Metrics](https://www.microsoft.com/typography/otspec/os2.htm#fss)** **must be enabled
 
-This will force MS Applications to use the `Typo` values instead of the `Win` values for line spacing. By doing this, we can freely set the `Win` values to avoid clipping and control the line height with the `Typo` values. It has the added benefit of future line height compatibility. When a new script is added, we simply change the `Win` values to the new `yMin` and `yMax`, without needing to worry if the line height have changed. Note that the `Use_Typo_Metric` flag is also called `fsSelection bit 7 `(related to how it is set in the OS/2 table).
+This will force Microsoft Applications to use the `Typo` values instead of the `Win` values for line spacing. By doing this, we can freely set the `Win` values to avoid clipping and control the line height with the `Typo` values. It has the added benefit of future line height compatibility. When a new script is added, we simply change the `Win` values to the new `yMin` and `yMax`, without needing to worry if the line height have changed. Note that the `Use_Typo_Metric` flag is also called `fsSelection bit 7 `(related to how it is set in the OS/2 table).
 
 -   In Glyphs.app, set `Use_Typo_Metrics` custom parameter to `true` in the **Font** tab of **Font Info**.
 -   In RoboFont, this is under **Font Info \> OpenType \> OS/2 Table \> fsSelection \> USE_TYPO_METRICS**.
@@ -94,7 +94,7 @@ Web designers will thank you if you managed to have the same space above and und
 
 #### 10. typo/hheaAscender value should leave open room for stacked diacritics.
 
-Following recent tests to confirm our VM policies, we now require that the typo/hheaAscender be equal to `A breve acute`. For families with multiple weights you must use the tallest `A breve acute` (in e.g., the Black master) as the reference point to guarantee uniform positioning across the entire font family.
+Following recent tests to confirm our vertical metrics policies, we now require that the typo/hheaAscender be equal to `A breve acute`. For families with multiple weights you must use the tallest `A breve acute` (in e.g., the Black master) as the reference point to guarantee uniform positioning across the entire font family.
 
 Even if the font does not support Vietnamese yet, we strongly suggest estimating the ascenders value foreseeing the `A breve acute` height based two main reasons:
 
@@ -121,7 +121,7 @@ Exceptions are usually made if the font’s primary script isn’t Latin, Greek 
 
 Please keep in mind that this calculation is to be set according to the specificities of each font.
 
--   The 120% suggested above is for compatibility with DTP apps (like InDesign automatic alignment ratio). Still, it can often be too tight if your font covers more languages than basic Latin, Greek, and Cyrillic, or if you have a particular design with short ascenders.  
+-   The 120% suggested above is for compatibility with desktop publishing apps (like InDesign automatic alignment ratio). Still, it can often be too tight if your font covers more languages than basic Latin, Greek, and Cyrillic, or if you have a particular design with short ascenders.  
 -   Please pay careful attention to the overall design of diacritic marks, especially the [stacked diacritics](https://googlefonts.github.io/gf-guide/diacritics.html#stacked-diacritics). This way you ensure the ascenders value is not unnecessarily high. You could also determine an ideal line spacing and then draw the diacritics accordingly or adapt them to it.
 -   Google Fonts is trying to push designers to include proper support of the [mark-to-mark](https://googlefonts.github.io/gf-guide/diacritics.html#the-glyph-positioning-gpos-table) feature allowing combination of diacritics and display of non-encoded accented glyphs. Pay attention to your anchor placement so that, if you combine breve and acute for example, you don't end up with a severe interline glyph clashing. 
 

--- a/gf-guide/metrics.md
+++ b/gf-guide/metrics.md
@@ -92,9 +92,14 @@ The `LineGap` value is a space added to the line height created by the union of 
 
 Web designers will thank you if you managed to have the same space above and under capitals: `typoAscender - CapsHeight = abs(typoDescender)`. It will make easier for them the setting of padding in buttons for example.
 
-#### 10. typo/hheaAscender value should be greater than Agrave's yMax when it makes sense
+#### 10. typo/hheaAscender value should leave open room for stacked diacritics.
 
-Some Mac applications such as TextEdit will position the first line of text by, either, using the height of the `A grave`, or by using the font’s `hheaAscender` (whichever is taller). To keep the positioning consistent across a family, we require that the `hheaAscender` is greater than the tallest `A grave` in the family. See this issue for further info, <https://github.com/googlefonts/fontbakery/issues/3170>.
+Our minimal required Glyphset for any new family is GF Latin Core, which includes Vietnamese support. Following recent tests to confirm our VM policies, we now require that the typo/hheaAscender be equal to or slightly higher than `A breve acute`. To guarantee uniform positioning across the entire font family, you must use the tallest `A breve acute` as the reference point.
+
+Even if, for any particular reason, the font does not currently support Vietnamese yet, we strongly suggest estimating the ascenders value foreseeing this glyph height for two main reasons
+
+- Once the font is published, it is not possible to modify the vertical metric values. By implementing the above approach, we can keep the option of updating the font in the future to support additional languages.
+- Certain Mac applications, including TextEdit, determine the height of the first line of text by either the `A grave` height or the font's `hheaAscender`, whichever is taller (for additional information on this topic, please refer to this issue: <https://github.com/googlefonts/fontbakery/issues/3170>). So using the suggested `A breve acute` glyph height will prevent clipping in such applications.
 
 #### 11. The sum of the font’s vertical metric values (absolute) should be 20-30% greater than the font’s UPM
 


### PR DESCRIPTION
This PR includes some adjustments and updates to the Vertical Metrics policies. 

**Vertical Metrics Requirements**
- [x] Requirements reordered 
- [x] Since the new minimum GF Latin Core glyphset now includes Vietnamese support. Updating the reference glyph to calculate ascenders value taking `Abreveacute` as a new reference.
- [x] Updating the notes, adding a reference to stacked diacritics design, and also the first example of concrete cases.
- [x] Pointing at Diffenator2 instead of [GF Regressions](https://github.com/googlefonts/gfregression) (which web version seems not to be working) and `gen-html` 

**Diacritic marks**
- [x] Reinforcing the requirement to include a set of marks for capital letters
- [x] Adding details to the stacked diacritics sub-section.

Links to the rendered files for a better review:

- [Diacritics](https://github.com/googlefonts/googlefonts.github.io/pull/102/files?short_path=be3858e#diff-be3858e9f1ce41b8ee8682dae9a4ebc1ed54e7decb6b5e09e3634c8099c0a049)
- [Vertical Metrics](https://github.com/googlefonts/googlefonts.github.io/pull/102/files?short_path=3e02c6e#diff-3e02c6ee52e21b6c0df96887a8d57733cf73743caf7c46515a29410b135b20c1)
