### PR TITLE
Clarify source file requirements

### DIFF
--- a/gf-guide/build.md
+++ b/gf-guide/build.md
@@ -309,7 +309,7 @@ Unfortunately, the Builder can’t do everything yet. You will have to use an ex
 -   To generate `WOFF`. use **[homebrew webfont tools](https://github.com/bramstein/homebrew-webfonttools)**.
 -   To hint OTF: use **[AFDKO](https://github.com/adobe-type-tools/afdko)**.
 -   To subset the font: use **[Fonttools’ subsetter](https://fonttools.readthedocs.io/en/latest/subset/index.html)**.
--   If you are using any other font format than `.glyphs` and `.ufo`: the build script should contain a step that converts the sources to UFO. Use **[Fontlab to UFO](https://pypi.org/project/vfb2ufo3/)** or **[FontForge to UFO](https://github.com/fontforge/sfd2ufo)** for example.
+-   If you are using any other font format than `.glyphs`, `.glyphspackage`, and `.ufo`: the build script should contain a step that converts the sources to UFO. Use **[Fontlab to UFO](https://pypi.org/project/vfb2ufo3/)** or **[FontForge to UFO](https://github.com/fontforge/sfd2ufo)** for example.
 
 <div class="next-reading">
     Further reading:<br>

--- a/gf-guide/onboarding.md
+++ b/gf-guide/onboarding.md
@@ -69,8 +69,7 @@ If you would like to include a new font family in the Google Fonts collection, w
     
 -   **The source files are available** in your preferred font editor format.
     <br>
-    The file formats most used are `UFO`, `.glyphs`, `fontforge` or `fontlab 7`. `Fontlab V` files must be converted to another format because the software runs only on older OS versions. 
-    
+    The file formats most used are `UFO`, `.glyphs`, `fontforge` or `fontlab 7`. `Fontlab V` files must be converted to another format because the software runs only on older OS versions. If you are using any font format other than `.glyphs` and `.ufo`, include a build script that converts the sources to UFO, and include the UFO sources in the Git repository. Use **[Fontlab to UFO](https://pypi.org/project/vfb2ufo3/)** or **[FontForge to UFO](https://github.com/fontforge/sfd2ufo)** for example.    
 -   **The build should follow the [Scalable Font Production principle](production.md).**
     <br>
     Fonts are built using [Fontmake](https://github.com/googlefonts/fontmake), which can generate binaries from `UFO`. Fontmake can also convert `.glyphs` files to UFO, but if you are using any other font format, your build process should contain a step that converts the sources to UFO. Read the chapter about [building fonts](build.md) to know more about the build process.

--- a/gf-guide/onboarding.md
+++ b/gf-guide/onboarding.md
@@ -69,7 +69,9 @@ If you would like to include a new font family in the Google Fonts collection, w
     
 -   **The source files are available** in your preferred font editor format.
     <br>
-    The file formats most used are `UFO`, `.glyphs`, `fontforge` or `fontlab 7`. `Fontlab V` files must be converted to another format because the software runs only on older OS versions. If you are using any font format other than `.glyphs` and `.ufo`, include a build script that converts the sources to UFO, and include the UFO sources in the Git repository. Use **[Fontlab to UFO](https://pypi.org/project/vfb2ufo3/)** or **[FontForge to UFO](https://github.com/fontforge/sfd2ufo)** for example.    
+    The file formats most used are `UFO`, `.glyphs`, `.glyphspackage`, `fontforge` or `fontlab 7`.
+    <br><br>`.glyphspackage` is preferred over `.glyphs` due to it being easier to work with in version control (Git). `Fontlab V` files must be converted to another format because the software runs only on older OS versions. If you are using any font format other than `.glyphs`, `.glyphspackage`, and `.ufo`, include a build script that converts the sources to UFO, and include the UFO sources in the Git repository. Use **[Fontlab to UFO](https://pypi.org/project/vfb2ufo3/)** or **[FontForge to UFO](https://github.com/fontforge/sfd2ufo)** for example.
+
 -   **The build should follow the [Scalable Font Production principle](production.md).**
     <br>
     Fonts are built using [Fontmake](https://github.com/googlefonts/fontmake), which can generate binaries from `UFO`. Fontmake can also convert `.glyphs` files to UFO, but if you are using any other font format, your build process should contain a step that converts the sources to UFO. Read the chapter about [building fonts](build.md) to know more about the build process.

--- a/gf-guide/production.md
+++ b/gf-guide/production.md
@@ -43,7 +43,8 @@ Fonts to be onboarded to Google Fonts are expected to abide by the following req
 
 -   **The design source files (plus scripts) are available** in your preferred font editor format.
     <br>
-    The file formats most used are `UFO`, `.glyphs`, `fontforge` or `fontlab 7`. `Fontlab V` files must be converted to another format because the software runs only on older OS versions.
+    The file formats most used are `UFO`, `.glyphs`, `fontforge` or `fontlab 7`. `Fontlab V` files must be converted to another format because the software runs only on older OS versions. If you are using any font format other than `.glyphs` and `.ufo`, include a build script that converts the sources to UFO, and include the UFO sources in the Git repository. Use **[Fontlab to UFO](https://pypi.org/project/vfb2ufo3/)** or **[FontForge to UFO](https://github.com/fontforge/sfd2ufo)** for example.
+
 
 -   **Fonts should be built using open-source tools**.** This ensures that they can be built under the same conditions on any platform.
 

--- a/gf-guide/production.md
+++ b/gf-guide/production.md
@@ -43,7 +43,8 @@ Fonts to be onboarded to Google Fonts are expected to abide by the following req
 
 -   **The design source files (plus scripts) are available** in your preferred font editor format.
     <br>
-    The file formats most used are `UFO`, `.glyphs`, `fontforge` or `fontlab 7`. `Fontlab V` files must be converted to another format because the software runs only on older OS versions. If you are using any font format other than `.glyphs` and `.ufo`, include a build script that converts the sources to UFO, and include the UFO sources in the Git repository. Use **[Fontlab to UFO](https://pypi.org/project/vfb2ufo3/)** or **[FontForge to UFO](https://github.com/fontforge/sfd2ufo)** for example.
+    The file formats most used are `UFO`, `.glyphs`, `.glyphspackage`, `fontforge` or `fontlab 7`.
+    <br><br>`.glyphspackage` is preferred over `.glyphs` due to it being easier to work with in version control (Git). `Fontlab V` files must be converted to another format because the software runs only on older OS versions. If you are using any font format other than `.glyphs`, `.glyphspackage`, and `.ufo`, include a build script that converts the sources to UFO, and include the UFO sources in the Git repository. Use **[Fontlab to UFO](https://pypi.org/project/vfb2ufo3/)** or **[FontForge to UFO](https://github.com/fontforge/sfd2ufo)** for example.
 
 
 -   **Fonts should be built using open-source tools**.** This ensures that they can be built under the same conditions on any platform.


### PR DESCRIPTION
It is not clear in multiple sections of the GF-Guide that `.ufo`, `.glyphspackage`, and `.glyphs` are the only formats that currently fully work in the Google Fonts system.

I also added reference to the `.glyphspackage` format in all sections of the docs where source files are discussed and encouraged its use. The reasoning being that `.glyphspackage` is easier to use with version control and also makes merging PRs to the source files easer because you don't have to overwrite the full file, which requires a lot of trust and can introduce unintended changes.