### PR TITLE
Update metadata.md: classification field

### DIFF
--- a/gf-guide/metadata.md
+++ b/gf-guide/metadata.md
@@ -129,7 +129,7 @@ source {
 }
 minisite_url: "https://myfontwebsite.com"
 stroke: "SERIF"
-classification: "MONOSPACE"
+classifications: "MONOSPACE"
 ```
 
 ## Description of Keys
@@ -181,7 +181,7 @@ Typographic classifications, one of 5 possible values:
 -   `category: "HANDWRITING"`
 -   `category: "MONOSPACE"`
 
-In 2023 the `category` field was augmented with two new fields called `stroke` and `classification`, the category field will continue to exist with no changes to its semantics. We are keeping the `category` field as is because Google products like Workspace and Ads use them and we didn't want to affect those products.
+In 2023 the `category` field was augmented with two new fields called `stroke` and `classifications`, the category field will continue to exist with no changes to its semantics. We are keeping the `category` field as is because Google products like Workspace and Ads use them and we didn't want to affect those products.
 
 This key is deprecated in the API (cf. below Stroke and Classification), but still mandatory to fill up in METADATA.pb
 
@@ -396,14 +396,14 @@ minisite_url: "https://myfontwebsite.com"
 
 The classification field is a repeated field that can be any combination of Handwriting, Display, Monospace, or Symbols, or it can not be set. So for example, if a font is Handwriting, Display and Monospace all at the same time, use all three. If it does not fit into any of those classifications, there is no need to use the field.
 
--   `classification: "HANDWRITING"`
--   `classification: "DISPLAY"`
--   `classification: "MONOSPACE"`
--   `classification: "SYMBOLS"`
+-   `classifications: "HANDWRITING"`
+-   `classifications: "DISPLAY"`
+-   `classifications: "MONOSPACE"`
+-   `classifications: "SYMBOLS"`
 
 ### Stroke
 
-The stroke field has a single value that is one of `SANS_SERIF`, `SERIF`, `SLAB_SERIF`. It should always be set if one of those options accurately describes the design since some features in the UI only look at the stroke value for some things. Otherwise, if one of the options doesn't describe the design, it can not be set. Google Fonts Search UI will present `stroke` and `classification` as separate search groups so users can combine them and search, say, for fonts that are Serif and Display.
+The stroke field has a single value that is one of `SANS_SERIF`, `SERIF`, `SLAB_SERIF`. It should always be set if one of those options accurately describes the design since some features in the UI only look at the stroke value for some things. Otherwise, if one of the options doesn't describe the design, it can not be set. Google Fonts Search UI will present `stroke` and `classifications` as separate search groups so users can combine them and search, say, for fonts that are Serif and Display.
 
 -   `stroke: "SANS_SERIF"`
 -   `stroke: "SERIF"`


### PR DESCRIPTION
cc @m4rc1e 
CLASSIFICATION -> CLASSIFICATIONS
According: https://github.com/googlefonts/gftools/blob/main/Lib/gftools/fonts_public.proto#L57

Written without `s`, we get:
<div><details><summary>☠ <b>FATAL:</b> Check METADATA.pb parse correctly. (<a href="https://font-bakery.readthedocs.io/en/stable/fontbakery/profiles/googlefonts.html#com.google.fonts/check/metadata/parses">com.google.fonts/check/metadata/parses</a>)</summary><div>
* ☠ **FATAL** Family metadata at . failed to parse.
TRACEBACK:
28:1 : Message type "google.fonts_public.FamilyProto" has no field named "classification". [code: parsing-error]
</div></details><details><summary>🔥 <b>FAIL:</b> Check for codepoints not covered by METADATA subsets. (<a href="https://font-bakery.readthedocs.io/en/stable/fontbakery/profiles/googlefonts.html#com.google.fonts/check/metadata/unreachable_subsetting">com.google.fonts/check/metadata/unreachable_subsetting</a>)</summary><div>


* 🔥 **FAIL** Could not parse metadata.pb file [code: unparsable-metadata]
</div></details>