### PR TITLE
fix: link pointing to invalid directory fixed

### DIFF
--- a/gf-guide/hosting.md
+++ b/gf-guide/hosting.md
@@ -225,5 +225,5 @@ git config core.ignorecase false
 
 <div class="next-reading">
     Further reading:<br>
-    <mark class="green"><b>must&rarr;</b></mark> <a href="./readme" style="font-weight:bold">Upstream repository structure</a>
+    <mark class="green"><b>must&rarr;</b></mark> <a href="./upstream.html" style="font-weight:bold">Upstream repository structure</a>
 </div>


### PR DESCRIPTION
changed url directory from /readme to /upstream.html on hosting.html page
![image](https://github.com/googlefonts/googlefonts.github.io/assets/156223429/94793cac-5df9-4d1c-aa82-750e1f689e7b)

<img width="769" alt="Screenshot 2024-02-12 110020" src="https://github.com/googlefonts/googlefonts.github.io/assets/156223429/f168fe6f-810b-4486-9c09-981377e80ee2">

