### PR TITLE
Remove animal icons at start of intro boxes

### DIFF
--- a/gf-guide/article.md
+++ b/gf-guide/article.md
@@ -7,7 +7,7 @@
 
 <div class="callout">
 
-🦉 Both the <mark class="grey">ARTICLE.en_us.html</mark> and <mark class="grey">DESCRIPTION.en_us.html</mark> files are used to bring the information that appears in the <code>#About</code> section on any specimen page of <a href="https://fonts.google.com">Google Fonts</a> to provide further information about the font family.
+Both the <mark class="grey">ARTICLE.en_us.html</mark> and <mark class="grey">DESCRIPTION.en_us.html</mark> files are used to bring the information that appears in the <code>#About</code> section on any specimen page of <a href="https://fonts.google.com">Google Fonts</a> to provide further information about the font family.
 <br><br>
 The team member onboarding the font will create any of these files. Thus, the actual file a designer should write carefully is the <a href="./readmefile">README.md</a> file of the font's repository, as the information in it will be crucial to create a descriptive <a href="https://fonts.google.com/specimen/Kalnia#about">#About</a> section.
 

--- a/gf-guide/authors.md
+++ b/gf-guide/authors.md
@@ -7,7 +7,7 @@
 
 <div class="callout">
 
-🦤 Authors and contributors are people or industries participating into a project either because they paid for it, they employed people who created and produced it, or because they are the people who made it.
+Authors and contributors are people or industries participating into a project either because they paid for it, they employed people who created and produced it, or because they are the people who made it.
 
 <ul>
     <li> The list of authors generally includes the creators and all the possible copyright holders (such as the company employing the actual creators). This may differ according to the copyright laws of the author’s country; better to inform yourself if the project was commissioned by an instiution or a company.</li>

--- a/gf-guide/axis-registry.md
+++ b/gf-guide/axis-registry.md
@@ -7,7 +7,7 @@
 
 <div class="callout">
 
-🕷 Type designers are familiar with the five axes already defined by Microsoft in the OpenType specification. However, for each new variable font that type designer develops, it often introduces new axes. In order for a family introducing new custom axes to be added to the Google Fonts API and Catalog, each axis it offers must be “registered” – it must have a definition in the <a href="github.com/googlefonts/axisregistry" target=_blank> GF Axis Registry</a>. 
+Type designers are familiar with the five axes already defined by Microsoft in the OpenType specification. However, for each new variable font that type designer develops, it often introduces new axes. In order for a family introducing new custom axes to be added to the Google Fonts API and Catalog, each axis it offers must be “registered” – it must have a definition in the <a href="github.com/googlefonts/axisregistry" target=_blank> GF Axis Registry</a>. 
 <br><br>
 The requirements and principles of axis definition have been established mainly by a cross-functional group of fonts team members by Q3 2022. This protocol provides a guide to handling it within the font project as part of the onboarding process to Google Fonts. It offers detailed information on the required information, how to define it, and the required steps.
 

--- a/gf-guide/build.md
+++ b/gf-guide/build.md
@@ -7,7 +7,7 @@
 
 <div class="callout">
 
-🦕 Because of our commitment to <a href="./cuture">Libre font culture</a>, all Google Fonts projects must be built using a reproducible, libre toolchain. We do not onboard binaries exported from font editors.
+Because of our commitment to <a href="./cuture">Libre font culture</a>, all Google Fonts projects must be built using a reproducible, libre toolchain. We do not onboard binaries exported from font editors.
 
 This chapter aims to guide designers in building their font binaries using open-source tools as per our production requirements. Everything related to font file settings is detailed in the <a href="https://googlefonts.github.io/gf-guide/index#pre-production-getting-your-fonts-ready-for-gf">Pre-production</a> section of this guide, and for practicality, that information will not be repeated here.
 <br><br>

--- a/gf-guide/culture.md
+++ b/gf-guide/culture.md
@@ -7,7 +7,7 @@
 
 <div class="callout">
 
-🦉 The design community and the tech community traditionally have very different cultures. Designer culture often involves the work of a single artist-designer that usually prefers to protect their artwork, while software developers generally cannot operate in such a solitary fashion: their work, even if it is copyrighted, is often based on the work of others and more subject to fragmented authorship.
+The design community and the tech community traditionally have very different cultures. Designer culture often involves the work of a single artist-designer that usually prefers to protect their artwork, while software developers generally cannot operate in such a solitary fashion: their work, even if it is copyrighted, is often based on the work of others and more subject to fragmented authorship.
 <br><br>
 Since fonts are software, Google Fonts works at the intersection of the two communities and, for many reasons, has embraced the Libre software culture to promote the creation, development, and distribution of typefaces. This culture encourages participation and learning while facilitating sharing and collaboration through the openness of the work and a more flexible licensing schema.
 <br><br>

--- a/gf-guide/diacritics.md
+++ b/gf-guide/diacritics.md
@@ -7,7 +7,7 @@
 
 <div class="callout">
 
-🐳 A diacritic is a mark used in combination with a base letter for many purposes, such as modifying the pronunciation by extending a basic alphabet to include more phonemes; adding stress that could differentiate similar words, hence meanings; and, in some languages, adding or modifying a vowel in a word.
+A diacritic is a mark used in combination with a base letter for many purposes, such as modifying the pronunciation by extending a basic alphabet to include more phonemes; adding stress that could differentiate similar words, hence meanings; and, in some languages, adding or modifying a vowel in a word.
 <br><br>
 Many diacritics are separated from the base letter, and can be placed above, below, aside, or through it; while other diacritics connect to the base. 
 <br><br>

--- a/gf-guide/fonttables.md
+++ b/gf-guide/fonttables.md
@@ -7,7 +7,7 @@
 
 <div class="callout">
 
-🦦 Understanding the what are the font tables and what they do is a core skill in font engineering.
+Understanding the what are the font tables and what they do is a core skill in font engineering.
 <br><br>
 <b>You can view the name tables using these tools:</b>
 <ul>

--- a/gf-guide/googlefonts.md
+++ b/gf-guide/googlefonts.md
@@ -7,7 +7,7 @@
 
 <div class="callout">
 
-🦉 <a href="https://github.com/google/fonts" target="_blank">google/fonts</a> is the GitHub repository that is used as a staging area to upload font families to <a href="https://fonts.google.com/" target="_blank">Google Fonts</a>. 
+<a href="https://github.com/google/fonts" target="_blank">google/fonts</a> is the GitHub repository that is used as a staging area to upload font families to <a href="https://fonts.google.com/" target="_blank">Google Fonts</a>. 
 <br><br>
 Once your project is ready, and you are sure it meets all the font and production requirements; as well as you have located your files in a GitHub repository that follows the required structure, then the definitive step to contributing your font to Google Fonts is to submit it as a Pull Request to google/fonts repository.
 <br><br>

--- a/gf-guide/hosting.md
+++ b/gf-guide/hosting.md
@@ -6,7 +6,7 @@
 {:.no_toc}
 
 <div class="callout">
-🐰 <b>Git</b>
+<b>Git</b>
 <br>
 Git is an open-source Version Control System (VCS) that runs on your local machine. It is a powerful tool that allows you to save discrete versions of a project as you work on it and makes it possible for collaborators to work together on code-based projects (including fonts) in a controlled manner.
 Using Git is essential to track the history of a project.

--- a/gf-guide/index.md
+++ b/gf-guide/index.md
@@ -4,7 +4,7 @@
 
 <div class="callout">
 
-🦜 This guide aims to help people navigate the requirements and recommendations for contributing to <a href="https://fonts.google.com">Google Fonts</a>. The contents covered here range from general knowledge to contextualize the <i>what</i> and <i>why</i> of some of the requirements as well as the specifics regarding technical aspects with some suggestions on how to comply with them. It covers different levels of information for both newcomers and more experienced contributors.
+This guide aims to help people navigate the requirements and recommendations for contributing to <a href="https://fonts.google.com">Google Fonts</a>. The contents covered here range from general knowledge to contextualize the <i>what</i> and <i>why</i> of some of the requirements as well as the specifics regarding technical aspects with some suggestions on how to comply with them. It covers different levels of information for both newcomers and more experienced contributors.
 
 Therefore, <b>this documentation is not meant to be read at once</b>. If you are already familiar with some of the concepts, for example, some people are more empowered with the use of Github please you can skip some chapters and jump to the other bits that you may be looking for. The guidelines have been separated into small bits to facilitate the search of specific information that you would need at a specific stage of the font production.
 

--- a/gf-guide/lang.md
+++ b/gf-guide/lang.md
@@ -6,7 +6,7 @@
 {:.no_toc}
 
 <div class="callout">
-🦜 <a href="https://github.com/googlefonts/lang" target="_blank">googlefonts/lang</a> is the GitHub repository that defines the foundation for the *lang metadata system* 
+<a href="https://github.com/googlefonts/lang" target="_blank">googlefonts/lang</a> is the GitHub repository that defines the foundation for the *lang metadata system* 
 <br><br>
 This section specifies the main concepts of the system and provides information on how if influences the displaying of the font in the Catalog.
 </div>

--- a/gf-guide/license-file.md
+++ b/gf-guide/license-file.md
@@ -7,7 +7,7 @@
 
 <div class="callout">
 
-🐰 Google initially accepted several libre licenses such as <mark class="grey">OFL</mark>, <mark class="grey">UFL</mark> and <mark class="grey">Apache</mark>.
+Google initially accepted several libre licenses such as <mark class="grey">OFL</mark>, <mark class="grey">UFL</mark> and <mark class="grey">Apache</mark>.
 But today only the OFL is accepted, and that has been the case for many years now.
 <br><br>
 This page flags some important requirements about the <mark class="grey">OFL</mark> license, as well as a template to copy-paste into your repo.

--- a/gf-guide/maintaining.md
+++ b/gf-guide/maintaining.md
@@ -7,7 +7,7 @@
 
 <div class="callout">
 
-🐰 A font is not finished just because it has been released. From time to time, you may want to update your design; users may find and report issues with the font that need to be addressed, or Google may commission you to update your own or someone else’s font.
+A font is not finished just because it has been released. From time to time, you may want to update your design; users may find and report issues with the font that need to be addressed, or Google may commission you to update your own or someone else’s font.
 <br><br>
 This guide will help designers to adopt good habits while maintaining their work within a GitHub repository.
 

--- a/gf-guide/making-pr.md
+++ b/gf-guide/making-pr.md
@@ -7,7 +7,7 @@
 
 <div class="callout">
 
-🐸 In order to submit a new family or an upgrade of an existing family on <a href="https://fonts.google.com/">fonts.google.com</a>, we must add or update the files held in the <a href="https://github.com/google/fonts">google/fonts</a> repository. This guide will help users submit Pull Requests (PR) which can then be reviewed and merged by a team member.
+In order to submit a new family or an upgrade of an existing family on <a href="https://fonts.google.com/">fonts.google.com</a>, we must add or update the files held in the <a href="https://github.com/google/fonts">google/fonts</a> repository. This guide will help users submit Pull Requests (PR) which can then be reviewed and merged by a team member.
 <br><br>
 
 <!-- Before submitting your pull request, make sure you have read the following documentations:

--- a/gf-guide/metadata.md
+++ b/gf-guide/metadata.md
@@ -7,7 +7,7 @@
 
 <div class="callout">
 
-🐸 The <mark class="grey">METADATA.pb</mark> file found in the Google Fonts <mark class="grey">library repo</mark> (<a href="https://github.com/google/fonts">github.com/google/fonts</a>) is a <a href="http://en.wikipedia.org/wiki/Protocol_buffers">Protocol Buffers</a> file that contains the main information about the font files served by Google Fonts, some of which typically corresponds to font file internal metadata.
+The <mark class="grey">METADATA.pb</mark> file found in the Google Fonts <mark class="grey">library repo</mark> (<a href="https://github.com/google/fonts">github.com/google/fonts</a>) is a <a href="http://en.wikipedia.org/wiki/Protocol_buffers">Protocol Buffers</a> file that contains the main information about the font files served by Google Fonts, some of which typically corresponds to font file internal metadata.
 
 </div>
 

--- a/gf-guide/metrics.md
+++ b/gf-guide/metrics.md
@@ -7,7 +7,7 @@
 
 <div class="callout">
 
-🐸 Vertical metrics are used to determine the space between two lines of text. Some metrics are meant for Mac, others for Windows, and they are interpreted differently according to web or desktop usage.
+Vertical metrics are used to determine the space between two lines of text. Some metrics are meant for Mac, others for Windows, and they are interpreted differently according to web or desktop usage.
 <br><br>
 Throughout countless threads and discussions, GF decided to prioritize cross-platform compatibility and, in consequence, apply the following requirements. Read them carefully because once a family is onboarded, vertical metrics are meant to remain always the same to avoid regression, as mentioned in <a href="./onboarding">Adding & upgrading fonts to Google Fonts</a>.
 <br><br>

--- a/gf-guide/onboarder-workflow.md
+++ b/gf-guide/onboarder-workflow.md
@@ -7,7 +7,7 @@
 
 <div class="callout">
 
-🐝 Google Fonts has become too big to be maintained as a simple community repository. The platform is now an API distributing and serving more than a thousand font families, and GF has started to see itself as a proper open-source foundry.
+Google Fonts has become too big to be maintained as a simple community repository. The platform is now an API distributing and serving more than a thousand font families, and GF has started to see itself as a proper open-source foundry.
 
 This means several things:
 

--- a/gf-guide/onboarding.md
+++ b/gf-guide/onboarding.md
@@ -7,7 +7,7 @@
 
 <div class="callout">
 
-🐸  Any contributions to Google Fonts should be first submitted through the <a href="https://github.com/google/fonts/issues">Google Fonts issue tracker</a>.
+Any contributions to Google Fonts should be first submitted through the <a href="https://github.com/google/fonts/issues">Google Fonts issue tracker</a>.
 
 Don't forget to search the issue tracker (using keywords) to see if your issue has already been raised before opening a new one. The following links can be used to create different kinds of issues:
 

--- a/gf-guide/outlines.md
+++ b/gf-guide/outlines.md
@@ -7,7 +7,7 @@
 
 <div class="callout">
 
-🐸  Make sure your font is ready for production by fulfilling the check-list below. Design is not particularly judged here, we are talking from the point of view of the technical quality aspect of a font, i.e: OS, browsers, apps and printers will be able to read the font file and display it as the designer intended.
+Make sure your font is ready for production by fulfilling the check-list below. Design is not particularly judged here, we are talking from the point of view of the technical quality aspect of a font, i.e: OS, browsers, apps and printers will be able to read the font file and display it as the designer intended.
 <br><br>
 Note that some font editors or export tools will partly do the job for you. Always test your exported fonts in different environments, open them in a font editor, or run a Fontbakery report on them, to make sure that everything looks like what you want.
 <br><br>

--- a/gf-guide/package.md
+++ b/gf-guide/package.md
@@ -7,7 +7,7 @@
 
 <div class="callout">
 
-🦦  <a href="https://github.com/googlefonts/gftools/tree/main/docs/gftools-packager">gftools packager</a> is the tool team members use to package fonts from the upstream repo to ship then to <a href="https://github.com/google/fonts">google/fonts</a> repo. It basically replaces <a href="./making-pr">Making a PR to GF</a> process. It saves a lot of time, and prevent lots of human mistakes.
+<a href="https://github.com/googlefonts/gftools/tree/main/docs/gftools-packager">gftools packager</a> is the tool team members use to package fonts from the upstream repo to ship then to <a href="https://github.com/google/fonts">google/fonts</a> repo. It basically replaces <a href="./making-pr">Making a PR to GF</a> process. It saves a lot of time, and prevent lots of human mistakes.
 <br><br>
 Note that Packager will create a branch on <code>google/fonts</code> directly. 
 </div>

--- a/gf-guide/production.md
+++ b/gf-guide/production.md
@@ -7,7 +7,7 @@
 
 <div class="callout">
 
-🐰 <a href="https://fonts.google.com/" target="_blank">Google Fonts</a> (GF) designates in fact two things. First, it is a <b>directory</b> of fonts, which can be downloaded and used locally on your machine. Second, it is also an <b>API</b> that delivers a web service: this means a website can request fonts, and Google Fonts delivers them to the website. In that second case, the fonts are hosted by Google Fonts and not by the website’s own server. 
+<a href="https://fonts.google.com/" target="_blank">Google Fonts</a> (GF) designates in fact two things. First, it is a <b>directory</b> of fonts, which can be downloaded and used locally on your machine. Second, it is also an <b>API</b> that delivers a web service: this means a website can request fonts, and Google Fonts delivers them to the website. In that second case, the fonts are hosted by Google Fonts and not by the website’s own server. 
 <br><br>
 This section will help users to understand the implications of publishing fonts on the Google Fonts platform, and will review the basic font production considerings and requirements that are mandatory for any Font to be included in the Catalog.
 

--- a/gf-guide/profile.md
+++ b/gf-guide/profile.md
@@ -7,7 +7,7 @@
 
 <div class="callout">
 
-🦥  This guide is a technical review of the different requirements related to the <a href="https://github.com/google/fonts/tree/main/catalog/designers">catalog/designers</a> directory in the <a href="https://github.com/google/fonts">google/fonts</a> repo.
+This guide is a technical review of the different requirements related to the <a href="https://github.com/google/fonts/tree/main/catalog/designers">catalog/designers</a> directory in the <a href="https://github.com/google/fonts">google/fonts</a> repo.
 <br><br>
 Each credited entity on Google Fonts should have a registered profile in <a href="https://github.com/google/fonts/tree/main/catalog/designers">google/fonts/catalog/designers</a>. This profile appears in the <code>Designer</code> subsection in the <a href="https://fonts.google.com/specimen/Praise?sort=date#about">about</a> section of the specimen page.
 <br><br>

--- a/gf-guide/promotion.md
+++ b/gf-guide/promotion.md
@@ -7,7 +7,7 @@
 
 <div class="callout">
 
-🦕 Fonts are carefully designed and offer a visual aid in communication, so the best way to display your project's advantages and subtle or powerful features is through images. That's why we now include images on every font's Specimen page on Google Fonts. 
+Fonts are carefully designed and offer a visual aid in communication, so the best way to display your project's advantages and subtle or powerful features is through images. That's why we now include images on every font's Specimen page on Google Fonts. 
 <br><br>
 This guide provides specifications for the required images for your typographic project published on Google Fonts. They will be added to the <a href="https://fonts.google.com/specimen/Ojuju/about">'About'</a> section of the specimen page, and, when a font is released for the first time on Google Fonts or if it benefited from a major upgrade, we can use them to promote the font on social media platforms (Mastodon, LinkedIn, Twitter, Instagram).
 

--- a/gf-guide/qa.md
+++ b/gf-guide/qa.md
@@ -7,7 +7,7 @@
 
 <div class="callout">
 
-🐯 Quality Assurance is an essential factor in Google Fonts. On the one hand, we expect the submitted fonts to follow the best standards and conventions of type design. On the other hand, committed to the understanding of fonts as software, we need to ensure that they fulfill the technical requirements of the major OS, applications, and browsers.
+Quality Assurance is an essential factor in Google Fonts. On the one hand, we expect the submitted fonts to follow the best standards and conventions of type design. On the other hand, committed to the understanding of fonts as software, we need to ensure that they fulfill the technical requirements of the major OS, applications, and browsers.
 <br><br>
 This chapter aims to guide designers to have a more automated approach of their binaries quality assurance. We recommend you install all the tools in a virtual environment, to avoid conflict between packages. Further information is detailed in the <a href="./tools">Tools and Dependencies section</a>. 
 <br><br>

--- a/gf-guide/readmefile.md
+++ b/gf-guide/readmefile.md
@@ -7,7 +7,7 @@
 
 <div class="callout">
 
-🦦  The README.md is a page you find at the root of any repository. It is the first readable text that a user can see when arriving in the repository on GitHub’s website.<br>
+The README.md is a page you find at the root of any repository. It is the first readable text that a user can see when arriving in the repository on GitHub’s website.<br>
 <ul>
     <li>GF wants to encourage you to share anything you think may be interesting or relevant about your typeface such as the inspiration, process, challenges you encountered, etc. So this is your moment. You can go wild and write a complete article if you feel like it. You can even include imagery to help illustrate the story.</li>
     <li>Take into account that this file will be taken as the base information that would be used to create the <a href="./description">Description file</a> that feeds the <code>#About</code> section of the specimen page of your font(s) on <code>fonts.google.com/Family+Name#about</code>, e.g. <b>Roboto</b> <a href="https://fonts.google.com/specimen/Roboto#about" target="_blank">https://fonts.google.com/specimen/Roboto#about</a>

--- a/gf-guide/requirements.md
+++ b/gf-guide/requirements.md
@@ -7,7 +7,7 @@
 
 <div class="callout">
 
-🦥  The following guidelines apply to all fonts, regardless of their format (static or variable fonts) or if you want to add a new font or update one already included in the catalog.
+The following guidelines apply to all fonts, regardless of their format (static or variable fonts) or if you want to add a new font or update one already included in the catalog.
 <br><br>
 For specific information on any of those cases, please read the pages with the requirements on them. before continuing.
 

--- a/gf-guide/statics.md
+++ b/gf-guide/statics.md
@@ -7,7 +7,7 @@
 
 <div class="callout">
 
-🐓  “Static” fonts is a way of saying traditional, <em>non-variable</em> fonts.
+“Static” fonts is a way of saying traditional, <em>non-variable</em> fonts.
 <br><br>
 Before going further, make sure you read carefully the <a href="./requirements">overall fonts requirements</a>. And please refer to the <a href="./variable">requirements about Variable Fonts</a> if you are developing a VF.
 <br><br>

--- a/gf-guide/tags.md
+++ b/gf-guide/tags.md
@@ -7,7 +7,7 @@
 
 <div class="callout">
 
-🐝 Since 2024, you can find different typographic categories on <a href="https://fonts.google.com/">Google Fonts</a> , making it easier to sort fonts and allowing users to refine their search.
+Since 2024, you can find different typographic categories on <a href="https://fonts.google.com/">Google Fonts</a> , making it easier to sort fonts and allowing users to refine their search.
 
 A new step has therefore been added to the font onboarding process, managed by the font onboarders, involving the use of a specially designed tool (*GF Tagger*, written by Marc Foley ✌️) to facilitate the addition of tags.
 

--- a/gf-guide/testing.md
+++ b/gf-guide/testing.md
@@ -7,7 +7,7 @@
 
 <div class="callout">
 
-🐸  This guide will help user to test their font locally to confirm quality-assurance. We recommend to test your font on the latest stable version of your OS and apps.
+This guide will help user to test their font locally to confirm quality-assurance. We recommend to test your font on the latest stable version of your OS and apps.
 <br><br>
 Bear in mind:
 <ul>

--- a/gf-guide/tools.md
+++ b/gf-guide/tools.md
@@ -7,7 +7,7 @@
 
 <div class="callout">
 
-🐰 Fonts published in Google Fonts comply with the Libre Fonts standards. Therefore, it is required that the fonts can be produced in a single step with open source tools. This ensures compliance with at least the first of the four <a href="./culture">freedoms</a> on which the Movement is based.
+Fonts published in Google Fonts comply with the Libre Fonts standards. Therefore, it is required that the fonts can be produced in a single step with open source tools. This ensures compliance with at least the first of the four <a href="./culture">freedoms</a> on which the Movement is based.
 <br><br>
 Before starting your project, you should set up a working environment with all the tools you will need in development. This guide will help users set up their environment to build the fonts with open source tools that Google Fonts is helping to develop.
 

--- a/gf-guide/upstream.md
+++ b/gf-guide/upstream.md
@@ -7,7 +7,7 @@
 
 <div class="callout">
 
-🐰 Font projects must be hosted on GitHub (or another VCS) and their repositories must be public. Google Fonts accepts private repositories while a project is still in progress, but they must be public once completed.
+Font projects must be hosted on GitHub (or another VCS) and their repositories must be public. Google Fonts accepts private repositories while a project is still in progress, but they must be public once completed.
 <br><br>
 This guide will help users understand what and why the requested directories, files, and documents are needed in a Google Fonts project.
 <br><br>

--- a/gf-guide/variable.md
+++ b/gf-guide/variable.md
@@ -7,7 +7,7 @@
 
 <div class="callout">
 
-🦥 The variable font technology has existed for a long time, but the format is actually quite recent (2016). It took time for OS and Apps to support this format, and some still did not make the step. In general, GF does not quite recommend the use of variable fonts in documents made to be printed.
+The variable font technology has existed for a long time, but the format is actually quite recent (2016). It took time for OS and Apps to support this format, and some still did not make the step. In general, GF does not quite recommend the use of variable fonts in documents made to be printed.
 <br><br>
 This guide will give users all the detailed information related to Variable fonts GF requirements. If you are developing a <em>Static</em> font project, please refere to the specifics on statics section.
 


### PR DESCRIPTION
Sometimes, icons may be used for a `<div>` box to indicate some sort of summary category/severity level of the paragraph, cf. e.g. <https://fedoraproject.org/wiki/Category:Font_wishlist>. Or, as a special case, used to obtain a copyable link, e.g. in the section headers of <https://fedoraproject.org/wiki/Category:Fonts_packaging>. Animal icons do not fall in either those two uses, and the GF Guide should not mimic school paper notes where someone was bored and drew doodles.